### PR TITLE
Fix `nodemon` not being able to watch for changes because `vite` is interfering 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "mocha": "^9.2.1",
         "nodemon": "^2.0.15",
         "prettier": "^2.5.1",
-        "vite": "^2.9.8"
+        "vite": "^2.9.6"
       },
       "engines": {
         "node": ">=16.0.0"
@@ -2965,9 +2965,9 @@
       }
     },
     "node_modules/minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
     },
     "node_modules/mkdirp": {
       "version": "1.0.4",
@@ -4455,13 +4455,13 @@
       }
     },
     "node_modules/vite": {
-      "version": "2.9.8",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-2.9.8.tgz",
-      "integrity": "sha512-zsBGwn5UT3YS0NLSJ7hnR54+vUKfgzMUh/Z9CxF1YKEBVIe213+63jrFLmZphgGI5zXwQCSmqIdbPuE8NJywPw==",
+      "version": "2.9.6",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-2.9.6.tgz",
+      "integrity": "sha512-3IffdrByHW95Yjv0a13TQOQfJs7L5dVlSPuTt432XLbRMriWbThqJN2k/IS6kXn5WY4xBLhK9XoaWay1B8VzUw==",
       "dev": true,
       "dependencies": {
         "esbuild": "^0.14.27",
-        "postcss": "^8.4.13",
+        "postcss": "^8.4.12",
         "resolve": "^1.22.0",
         "rollup": "^2.59.0"
       },
@@ -6791,9 +6791,9 @@
       }
     },
     "minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
     },
     "mkdirp": {
       "version": "1.0.4",
@@ -7880,14 +7880,14 @@
       }
     },
     "vite": {
-      "version": "2.9.8",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-2.9.8.tgz",
-      "integrity": "sha512-zsBGwn5UT3YS0NLSJ7hnR54+vUKfgzMUh/Z9CxF1YKEBVIe213+63jrFLmZphgGI5zXwQCSmqIdbPuE8NJywPw==",
+      "version": "2.9.6",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-2.9.6.tgz",
+      "integrity": "sha512-3IffdrByHW95Yjv0a13TQOQfJs7L5dVlSPuTt432XLbRMriWbThqJN2k/IS6kXn5WY4xBLhK9XoaWay1B8VzUw==",
       "dev": true,
       "requires": {
         "esbuild": "^0.14.27",
         "fsevents": "~2.3.2",
-        "postcss": "^8.4.13",
+        "postcss": "^8.4.12",
         "resolve": "^1.22.0",
         "rollup": "^2.59.0"
       }

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "mocha": "^9.2.1",
     "nodemon": "^2.0.15",
     "prettier": "^2.5.1",
-    "vite": "^2.9.8"
+    "vite": "^2.9.6"
   },
   "dependencies": {
     "express": "^4.17.2",


### PR DESCRIPTION
We use `vite@2.9.6` because `vite>=2.9.7` is interfering with `nodemon`, see https://github.com/vitejs/vite/issues/8492

This means that when using `npm run start-dev` -> [`start-dev.js`](https://github.com/matrix-org/matrix-public-archive/blob/40f9d2ea5afb74c4f04030fb1a643fcd803a70e7/server/start-dev.js), `nodemon` wasn't restarting when a change was made.