### PR TITLE
Remove extra body margin causing offset from viewport

### DIFF
--- a/public/styles/styles.css
+++ b/public/styles/styles.css
@@ -8,6 +8,10 @@ html {
   box-sizing: inherit;
 }
 
+body {
+  margin: 0;
+}
+
 /* Based on .SessionView from Hydrogen */
 .ArchiveView {
   /* this takes into account whether or not the url bar is hidden on mobile


### PR DESCRIPTION
Remove extra body margin causing offset from viewport

Before (hard to see but notice extra white space at top) | After
--- | ---
![](https://user-images.githubusercontent.com/558581/173145466-2d849d36-3fe9-4cbf-9448-e88a08bae13a.png) | ![](https://user-images.githubusercontent.com/558581/173145470-55249f63-7758-450f-8635-2a29b4c32b97.png)

