### PR TITLE
Fix image not running in K8s (ROSA)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16.15-buster-slim
+FROM node:16.14.2-buster-slim
 
 RUN mkdir -p /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,7 @@
+# XXX: Before updating this, make sure the issues around `npm` silently exiting
+# with error 243 issues are solved:
+#  - https://github.com/npm/cli/issues/4996
+#  - https://github.com/npm/cli/issues/4769
 FROM node:16.14.2-buster-slim
 
 RUN mkdir -p /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,6 @@ RUN mkdir -p /app
 
 WORKDIR /app
 
-RUN npm install npm@^8 --location=global
-
 # Copy the health-check script
 COPY docker-health-check.js /app/
 


### PR DESCRIPTION
Fix image not running in K8s (ROSA)

Trying to solve the container exiting with error code `243`. `npm` throws `243` for any command you try to run with it.

Here is how to get into the container while the entrypoint normally errors.
```
$ oc run -i --tty --image=ghcr.io/matrix-org/matrix-public-archive/matrix-public-archive:sha-65edaea1a9713bb2cc93fa98638327fdeff765cd mpa-test2 --port=3050 --restart=Never --env="DOMAIN=cluster" --command /bin/bash
$ npm start

$ echo $?
243
```

Why does the same image work in Docker?
```
$ docker run -it --entrypoint /bin/bash ghcr.io/matrix-org/matrix-public-archive/matrix-public-archive:sha-65edaea1a9713bb2cc93fa98638327fdeff765cd
$ npm start
# it starts ✅
```


## Root cause

Seems like it could be either of these issues. Both are `8.6.0`+ problems as well which lines up with the `npm` version available in each base image.

 - https://github.com/npm/cli/issues/4769
 - https://github.com/npm/cli/issues/4996
    - Specific comment about breaking stuff in k8s for other people, https://github.com/npm/cli/issues/4996#issuecomment-1150290804