### PR TITLE
Remove unneeded `include_redundant_members` from `/messages` `filter` and test that member state is still visible

### DIFF
--- a/test/e2e-tests.js
+++ b/test/e2e-tests.js
@@ -330,7 +330,8 @@ describe('matrix-public-archive', () => {
 
       // Make sure the user avatar is visible on the message
       const avatarImageElement = dom.document.querySelector(
-        // FIXME: Use more stable select here instead of `.avatar`
+        // FIXME: Use more stable select here instead of `.avatar`,
+        // see https://github.com/vector-im/hydrogen-web/pull/773
         `[data-event-id="${imageEventId}"] .avatar img`
       );
       assert(avatarImageElement);
@@ -338,7 +339,8 @@ describe('matrix-public-archive', () => {
 
       // Make sure the image message is visible
       const imageElement = dom.document.querySelector(
-        // FIXME: Use more stable select here instead of `.media`
+        // FIXME: Use more stable select here instead of `.media`,
+        // see https://github.com/vector-im/hydrogen-web/pull/773
         `[data-event-id="${imageEventId}"] .media img`
       );
       assert(imageElement);

--- a/test/e2e-tests.js
+++ b/test/e2e-tests.js
@@ -20,6 +20,7 @@ const {
   sendEvent,
   sendMessage,
   createMessagesInRoom,
+  updateProfile,
   uploadContent,
 } = require('./client-utils');
 
@@ -199,7 +200,23 @@ describe('matrix-public-archive', () => {
       const client = await getTestClientForHs(testMatrixServerUrl1);
       const roomId = await createTestRoom(client);
 
-      // TODO: Set avatar of user
+      const userAvatarBuffer = Buffer.from(
+        // Purple PNG pixel
+        'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mPsD9j0HwAFmQKScbjOAwAAAABJRU5ErkJggg==',
+        'base64'
+      );
+      const userAvatarMxcUri = await uploadContent({
+        client,
+        roomId,
+        data: userAvatarBuffer,
+        fileName: 'client user avatar',
+      });
+      const displayName = `${client.userId}-some-display-name`;
+      await updateProfile({
+        client,
+        displayName,
+        avatarUrl: userAvatarMxcUri,
+      });
 
       // TODO: Set avatar of room
 
@@ -305,8 +322,25 @@ describe('matrix-public-archive', () => {
 
       const dom = parseHTML(archivePageHtml);
 
+      // Make sure the user display name is visible on the message
+      assert.match(
+        dom.document.querySelector(`[data-event-id="${imageEventId}"]`).outerHTML,
+        new RegExp(`.*${escapeStringRegexp(displayName)}.*`)
+      );
+
+      // Make sure the user avatar is visible on the message
+      const avatarImageElement = dom.document.querySelector(
+        // FIXME: Use more stable select here instead of `.avatar`
+        `[data-event-id="${imageEventId}"] .avatar img`
+      );
+      assert(avatarImageElement);
+      assert.match(avatarImageElement.getAttribute('src'), new RegExp(`^http://.*`));
+
       // Make sure the image message is visible
-      const imageElement = dom.document.querySelector(`[data-event-id="${imageEventId}"] img`);
+      const imageElement = dom.document.querySelector(
+        // FIXME: Use more stable select here instead of `.media`
+        `[data-event-id="${imageEventId}"] .media img`
+      );
       assert(imageElement);
       assert.match(imageElement.getAttribute('src'), new RegExp(`^http://.*`));
       assert.strictEqual(imageElement.getAttribute('alt'), imageFileName);


### PR DESCRIPTION
Remove unneeded `include_redundant_members` from `/messages` `filter` and add tests to ensure member state is still visible.

Follow-up to https://github.com/matrix-org/matrix-public-archive/pull/28#discussion_r909428366

## Dev notes

Notice the purple user avatar and display name set.

`npm run test-interactive` -> diverse messages test

<img width="1074" alt="" src="https://user-images.githubusercontent.com/558581/176417599-3f2d8e9b-e967-409a-b7fd-4eeb096038cb.png">
