### PR TITLE
Use stable test selectors from Hydrogen (`data-testid`)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "express": "^4.17.2",
-        "hydrogen-view-sdk": "npm:@mlm/hydrogen-view-sdk@^0.0.12",
+        "hydrogen-view-sdk": "npm:@mlm/hydrogen-view-sdk@^0.0.13-scratch",
         "linkedom": "^0.14.1",
         "matrix-public-archive-shared": "file:./shared/",
         "nconf": "^0.11.3",
@@ -128,9 +128,9 @@
       "dev": true
     },
     "node_modules/@matrix-org/olm": {
-      "version": "3.2.3",
-      "resolved": "https://gitlab.matrix.org/api/v4/projects/27/packages/npm/@matrix-org/olm/-/@matrix-org/olm-3.2.3.tgz",
-      "integrity": "sha512-OhC9wwZ/ox9vputA1MR2A7QlYlvfXCV+tdbADOR7Jn7o9qoXh3HWf+AbSpXTK3daF0GIHA69Ws8XOnWqu5n53A==",
+      "version": "3.2.8",
+      "resolved": "https://gitlab.matrix.org/api/v4/projects/27/packages/npm/@matrix-org/olm/-/@matrix-org/olm-3.2.8.tgz",
+      "integrity": "sha512-yCJzEYY2aG1z+7nxKYZC4DFYwQO/5iG019qgotJhauYJRhEG9gLrKTvXO6lRHS8TjnZzsZFZyO/hQUlI4Dryig==",
       "license": "Apache-2.0"
     },
     "node_modules/@sindresorhus/is": {
@@ -1990,11 +1990,11 @@
     },
     "node_modules/hydrogen-view-sdk": {
       "name": "@mlm/hydrogen-view-sdk",
-      "version": "0.0.12",
-      "resolved": "https://registry.npmjs.org/@mlm/hydrogen-view-sdk/-/hydrogen-view-sdk-0.0.12.tgz",
-      "integrity": "sha512-zPmJJVUKQCIxw9vAwcTzwU9OT/U/9Gvspafx10l8a2flguj8BLBOorYw0EghBK/MdSsc//b+GRwpYqrvz8VAfQ==",
+      "version": "0.0.13-scratch",
+      "resolved": "https://registry.npmjs.org/@mlm/hydrogen-view-sdk/-/hydrogen-view-sdk-0.0.13-scratch.tgz",
+      "integrity": "sha512-LAytm2lqVCvpFriizKQXjSJgOomx29ReD6w2sQhbHIfeP5DZ6wNxRybCBeBFrU1+2BiT7BTNmZp5Cwe8PGt14Q==",
       "dependencies": {
-        "@matrix-org/olm": "https://gitlab.matrix.org/api/v4/projects/27/packages/npm/@matrix-org/olm/-/@matrix-org/olm-3.2.3.tgz",
+        "@matrix-org/olm": "https://gitlab.matrix.org/api/v4/projects/27/packages/npm/@matrix-org/olm/-/@matrix-org/olm-3.2.8.tgz",
         "another-json": "^0.2.0",
         "base64-arraybuffer": "^0.2.0",
         "dompurify": "^2.3.0",
@@ -3979,8 +3979,8 @@
       "dev": true
     },
     "@matrix-org/olm": {
-      "version": "https://gitlab.matrix.org/api/v4/projects/27/packages/npm/@matrix-org/olm/-/@matrix-org/olm-3.2.3.tgz",
-      "integrity": "sha512-OhC9wwZ/ox9vputA1MR2A7QlYlvfXCV+tdbADOR7Jn7o9qoXh3HWf+AbSpXTK3daF0GIHA69Ws8XOnWqu5n53A=="
+      "version": "https://gitlab.matrix.org/api/v4/projects/27/packages/npm/@matrix-org/olm/-/@matrix-org/olm-3.2.8.tgz",
+      "integrity": "sha512-yCJzEYY2aG1z+7nxKYZC4DFYwQO/5iG019qgotJhauYJRhEG9gLrKTvXO6lRHS8TjnZzsZFZyO/hQUlI4Dryig=="
     },
     "@sindresorhus/is": {
       "version": "0.14.0",
@@ -5265,11 +5265,11 @@
       }
     },
     "hydrogen-view-sdk": {
-      "version": "npm:@mlm/hydrogen-view-sdk@0.0.12",
-      "resolved": "https://registry.npmjs.org/@mlm/hydrogen-view-sdk/-/hydrogen-view-sdk-0.0.12.tgz",
-      "integrity": "sha512-zPmJJVUKQCIxw9vAwcTzwU9OT/U/9Gvspafx10l8a2flguj8BLBOorYw0EghBK/MdSsc//b+GRwpYqrvz8VAfQ==",
+      "version": "npm:@mlm/hydrogen-view-sdk@0.0.13-scratch",
+      "resolved": "https://registry.npmjs.org/@mlm/hydrogen-view-sdk/-/hydrogen-view-sdk-0.0.13-scratch.tgz",
+      "integrity": "sha512-LAytm2lqVCvpFriizKQXjSJgOomx29ReD6w2sQhbHIfeP5DZ6wNxRybCBeBFrU1+2BiT7BTNmZp5Cwe8PGt14Q==",
       "requires": {
-        "@matrix-org/olm": "https://gitlab.matrix.org/api/v4/projects/27/packages/npm/@matrix-org/olm/-/@matrix-org/olm-3.2.3.tgz",
+        "@matrix-org/olm": "https://gitlab.matrix.org/api/v4/projects/27/packages/npm/@matrix-org/olm/-/@matrix-org/olm-3.2.8.tgz",
         "another-json": "^0.2.0",
         "base64-arraybuffer": "^0.2.0",
         "dompurify": "^2.3.0",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "express": "^4.17.2",
-    "hydrogen-view-sdk": "npm:@mlm/hydrogen-view-sdk@^0.0.12",
+    "hydrogen-view-sdk": "npm:@mlm/hydrogen-view-sdk@^0.0.13-scratch",
     "linkedom": "^0.14.1",
     "matrix-public-archive-shared": "file:./shared/",
     "nconf": "^0.11.3",

--- a/test/e2e-tests.js
+++ b/test/e2e-tests.js
@@ -330,18 +330,14 @@ describe('matrix-public-archive', () => {
 
       // Make sure the user avatar is visible on the message
       const avatarImageElement = dom.document.querySelector(
-        // FIXME: Use more stable select here instead of `.avatar`,
-        // see https://github.com/vector-im/hydrogen-web/pull/773
-        `[data-event-id="${imageEventId}"] .avatar img`
+        `[data-event-id="${imageEventId}"] [data-testid="avatar"] img`
       );
       assert(avatarImageElement);
       assert.match(avatarImageElement.getAttribute('src'), new RegExp(`^http://.*`));
 
       // Make sure the image message is visible
       const imageElement = dom.document.querySelector(
-        // FIXME: Use more stable select here instead of `.media`,
-        // see https://github.com/vector-im/hydrogen-web/pull/773
-        `[data-event-id="${imageEventId}"] .media img`
+        `[data-event-id="${imageEventId}"] [data-testid="media"] img`
       );
       assert(imageElement);
       assert.match(imageElement.getAttribute('src'), new RegExp(`^http://.*`));


### PR DESCRIPTION
Use stable test selectors

Follow-up to https://github.com/matrix-org/matrix-public-archive/pull/29#discussion_r909492946

---

Updated Hydrogen to add the consistent `data-testid` attribute selectors,
https://github.com/vector-im/hydrogen-web/pull/773

```
npm install hydrogen-view-sdk@npm:@mlm/hydrogen-view-sdk@0.0.13-scratch
```
