### PR TITLE
Fix large option payloads throwing E2BIG and ENAMETOOLONG

### DIFF
--- a/server/hydrogen-render/1-render-hydrogen-to-string.js
+++ b/server/hydrogen-render/1-render-hydrogen-to-string.js
@@ -21,14 +21,15 @@ async function renderHydrogenToString(options) {
     const { signal } = controller;
     // We use a child_process because we want to be able to exit the process after
     // we receive the SSR results.
-    const child = fork(
-      require.resolve('./2-render-hydrogen-to-string-fork-script'),
-      [JSON.stringify(options)],
-      {
-        signal,
-        //cwd: process.cwd(),
-      }
-    );
+    const child = fork(require.resolve('./2-render-hydrogen-to-string-fork-script'), [], {
+      signal,
+      //cwd: process.cwd(),
+    });
+
+    // Pass the options to the child by sending instead of via argv because we
+    // will run into `Error: spawn E2BIG` and `Error: spawn ENAMETOOLONG` with
+    // argv.
+    child.send(options);
 
     // Stops the child process if it takes too long
     setTimeout(() => {

--- a/server/hydrogen-render/2-render-hydrogen-to-string-fork-script.js
+++ b/server/hydrogen-render/2-render-hydrogen-to-string-fork-script.js
@@ -6,6 +6,9 @@
 
 const _renderHydrogenToStringUnsafe = require('./3-render-hydrogen-to-string-unsafe');
 
+// Only kick everything off once we receive the options. We pass in the options
+// this way instead of argv because we will run into `Error: spawn E2BIG` and
+// `Error: spawn ENAMETOOLONG` with argv.
 process.on('message', async (options) => {
   try {
     const resultantHtml = await _renderHydrogenToStringUnsafe(options);

--- a/server/hydrogen-render/2-render-hydrogen-to-string-fork-script.js
+++ b/server/hydrogen-render/2-render-hydrogen-to-string-fork-script.js
@@ -4,17 +4,10 @@
 // get the data and exit the process cleanly. We don't want Hydrogen to keep
 // running after we get our initial rendered HTML.
 
-const assert = require('assert');
-
 const _renderHydrogenToStringUnsafe = require('./3-render-hydrogen-to-string-unsafe');
 
-(async () => {
+process.on('message', async (options) => {
   try {
-    assert(
-      process.argv[2],
-      'No command-line arguments passed to `render-hydrogen-to-string-fork-script.js`. Make sure these are being passed in when we spawn the new process.'
-    );
-    const options = JSON.parse(process.argv[2]);
     const resultantHtml = await _renderHydrogenToStringUnsafe(options);
 
     // Send back the data we need
@@ -35,4 +28,4 @@ const _renderHydrogenToStringUnsafe = require('./3-render-hydrogen-to-string-uns
     // Throw the error so the process fails and exits
     throw err;
   }
-})();
+});


### PR DESCRIPTION
Fix large option payloads throwing `E2BIG` and `ENAMETOOLONG` errors

Follow-up to https://github.com/matrix-org/matrix-public-archive/pull/36