### PR TITLE
Make sure we finish sending the HTML payload before we exit the process

### DIFF
--- a/server/hydrogen-render/1-render-hydrogen-to-string.js
+++ b/server/hydrogen-render/1-render-hydrogen-to-string.js
@@ -6,7 +6,7 @@
 
 const fork = require('child_process').fork;
 
-const { assert } = require('console');
+const assert = require('assert');
 const RethrownError = require('../lib/rethrown-error');
 
 // The render should be fast. If it's taking more than 5 seconds, something has

--- a/server/hydrogen-render/2-render-hydrogen-to-string-fork-script.js
+++ b/server/hydrogen-render/2-render-hydrogen-to-string-fork-script.js
@@ -4,6 +4,8 @@
 // get the data and exit the process cleanly. We don't want Hydrogen to keep
 // running after we get our initial rendered HTML.
 
+const assert = require('assert');
+
 const _renderHydrogenToStringUnsafe = require('./3-render-hydrogen-to-string-unsafe');
 
 // Only kick everything off once we receive the options. We pass in the options
@@ -13,12 +15,31 @@ process.on('message', async (options) => {
   try {
     const resultantHtml = await _renderHydrogenToStringUnsafe(options);
 
-    // Send back the data we need
-    process.send({
-      data: resultantHtml,
+    assert(resultantHtml, `No HTML returned from _renderHydrogenToStringUnsafe.`);
+
+    // Send back the data we need to the parent.
+    await new Promise((resolve, reject) => {
+      process.send(
+        {
+          data: resultantHtml,
+        },
+        (err) => {
+          if (err) {
+            return reject(err);
+          }
+
+          // Exit once we know the data was sent out. We can't gurantee the
+          // message was received but this should work pretty well.
+          //
+          // Related:
+          //  - https://stackoverflow.com/questions/34627546/process-send-is-sync-async-on-nix-windows
+          //  - https://github.com/nodejs/node/commit/56d9584a0ead78874ca9d4de2e55b41c4056e502
+          //  - https://github.com/nodejs/node/issues/6767
+          process.exit(0);
+          resolve();
+        }
+      );
     });
-    // End the process gracefully. We got all the data we need.
-    process.exit(0);
   } catch (err) {
     // Serialize the error and send it back up to the parent process so we can
     // interact with it and know what happened when the process exits.

--- a/server/hydrogen-render/3-render-hydrogen-to-string-unsafe.js
+++ b/server/hydrogen-render/3-render-hydrogen-to-string-unsafe.js
@@ -94,6 +94,7 @@ async function _renderHydrogenToStringUnsafe({ fromTimestamp, roomData, events, 
   await vmResult;
 
   const documentString = dom.document.body.toString();
+  assert(documentString, 'Document body should not be empty after we rendered Hydrogen');
   return documentString;
 }
 


### PR DESCRIPTION
Make sure we finish sending the HTML payload before we exit the process.

I encountered a page which responded successfully but all of the Hydrogen HTML was missing. It just had the boilerplate around it.

What I am guessing happened is that since `process.send` is async, with a sufficiently large
payload and race condition, `process.exit(0)` was being called before it finished sending.

Related:
 - https://stackoverflow.com/questions/34627546/process-send-is-sync-async-on-nix-windows
 - https://github.com/nodejs/node/commit/56d9584a0ead78874ca9d4de2e55b41c4056e502
 - https://github.com/nodejs/node/issues/6767