### PR TITLE
Manually instrument some archive logic so we get nice labeled spans of what's happening in the app (OpenTelemetry tracing).

### DIFF
--- a/server/fetch-events-in-range.js
+++ b/server/fetch-events-in-range.js
@@ -4,6 +4,7 @@ const assert = require('assert');
 const urlJoin = require('url-join');
 
 const { fetchEndpointAsJson } = require('./lib/fetch-endpoint');
+const { traceFunction } = require('./tracing/trace-utilities');
 
 const config = require('./lib/config');
 const matrixServerUrl = config.get('matrixServerUrl');
@@ -140,4 +141,4 @@ async function fetchEventsInRange(accessToken, roomId, startTs, endTs, limit) {
   };
 }
 
-module.exports = fetchEventsInRange;
+module.exports = traceFunction(fetchEventsInRange);

--- a/server/fetch-room-data.js
+++ b/server/fetch-room-data.js
@@ -4,6 +4,7 @@ const assert = require('assert');
 
 const urlJoin = require('url-join');
 const { fetchEndpointAsJson } = require('./lib/fetch-endpoint');
+const { traceFunction } = require('./tracing/trace-utilities');
 
 const config = require('./lib/config');
 const matrixServerUrl = config.get('matrixServerUrl');
@@ -48,4 +49,4 @@ async function fetchRoomData(accessToken, roomId) {
   };
 }
 
-module.exports = fetchRoomData;
+module.exports = traceFunction(fetchRoomData);

--- a/server/hydrogen-render/1-render-hydrogen-to-string.js
+++ b/server/hydrogen-render/1-render-hydrogen-to-string.js
@@ -8,6 +8,7 @@ const fork = require('child_process').fork;
 
 const assert = require('assert');
 const RethrownError = require('../lib/rethrown-error');
+const { traceFunction } = require('../tracing/trace-utilities');
 
 // The render should be fast. If it's taking more than 5 seconds, something has
 // gone really wrong.
@@ -105,4 +106,4 @@ async function renderHydrogenToString(options) {
   }
 }
 
-module.exports = renderHydrogenToString;
+module.exports = traceFunction(renderHydrogenToString);

--- a/server/tracing/trace-utilities.js
+++ b/server/tracing/trace-utilities.js
@@ -1,0 +1,62 @@
+'use strict';
+
+const assert = require('assert');
+const opentelemetryApi = require('@opentelemetry/api');
+
+const packageInfo = require('../../package.json');
+assert(packageInfo.name);
+assert(packageInfo.version);
+
+const tracer = opentelemetryApi.trace.getTracer(packageInfo.name, packageInfo.version);
+
+/**
+ * Wraps an existing function to instrument it with OpenTelemetry tracing. Now
+ * whenever the function runs, it will create a span with the given name. It's
+ * basically `tracer.startActiveSpan` with some sensible default behaviors to
+ * automatically end spans:
+ * - when function completes successfully, status of span also set
+ * - when function throws (exception recorded against span)
+ * - if function returns a Promise, the promise is resolved
+ * @param name Span name, passed through to `tracer.startActiveSpan`
+ * @param fn The function to wrap
+ * @returns The wrapped function
+ *
+ * via
+ * https://github.com/open-telemetry/opentelemetry-js-api/issues/164#issuecomment-1174925516
+ */
+function trace(name, fn) {
+  return function (...args) {
+    return tracer.startActiveSpan(name, async (span) => {
+      try {
+        const result = await Promise.resolve(fn(...args));
+        span.setStatus({
+          code: opentelemetryApi.SpanStatusCode.OK,
+        });
+        return result;
+      } catch (e) {
+        const err = e;
+        span.recordException(err);
+        span.setStatus({
+          code: opentelemetryApi.SpanStatusCode.ERROR,
+          message: err.message,
+        });
+        throw err;
+      } finally {
+        span.end();
+      }
+    });
+  };
+}
+
+/**
+ * Wraps an existing function to instrument it with OpenTelemetry tracing. The
+ * span name will be the name of the function.
+ */
+function traceFunction(fn) {
+  return trace(fn.name, fn);
+}
+
+module.exports = {
+  trace,
+  traceFunction,
+};


### PR DESCRIPTION
Manually instrument some archive logic so we get nice labeled spans of what's happening in the app (OpenTelemetry tracing).

Before | After
--- | ---
![](https://user-images.githubusercontent.com/558581/180585810-e9726467-0aff-4dac-b78c-c5eb3ebd0179.png) | ![](https://user-images.githubusercontent.com/558581/180585812-0c0be4b9-a754-4ab4-a910-7326c8c5c63c.png)


## Soo, how slow is running in the `child_process`?

**Update:** Tracking all of this information in https://github.com/matrix-org/matrix-public-archive/issues/49

In https://github.com/matrix-org/matrix-public-archive/pull/36, we started wrapping our whole rendering Hydrogen `vm` flow in a `child_process` because using a Node.js `vm` context doesn't have a way to stop the process (it just keeps running). With the `child_process` we can kill it when we choose after we get the HTML result.

Now with this timing, we can also get some insight into how bad of a performance hit having to run the hydrogen render in the `child_process` is. It seems to be a lot slower: ~50ms vs 360ms.

```js
// Use the `vm` directly to see how fast it is
const _renderHydrogenToStringUnsafe = require('../hydrogen-render/3-render-hydrogen-to-string-unsafe');
const hydrogenHtmlOutput = await _renderHydrogenToStringUnsafe({ /* renderData */ });
```

![](https://user-images.githubusercontent.com/558581/180586026-ff6c653e-a54d-4cf4-abc8-a8c51971aad5.png)


#### Should we switch away from `child_process`?

Maybe.

We could use the `vm` `script.runInNewContext(...)` `timeout` option and just accept that it will be living for 5 seconds (or whatever we timeout we choose) before it dies. We already choose to kill the `child_process` after 5 seconds if it takes too long since we expect the Hydrogen render part to be fast.

Or maybe abuse the `vm` `script.runInNewContext(...)` `breakOnSigint` option and send a `SIGINT` to kill it. Need to be careful not to kill our main process.

Is it possible just to reset and render Hydrogen over and over with the same VM context? We could do a similar thing and keep the `child_process` alive and share for all renders.


