### PR TITLE
Use JSON5 for configuration files with comments

### DIFF
--- a/config/config.default.json
+++ b/config/config.default.json
@@ -5,10 +5,10 @@
   "archiveMessageLimit": 500,
   "requestTimeoutMs": 25000,
   "logOutputFromChildProcesses": false,
-  "UNCOMMENT_jaegerTracesEndpoint": "http://localhost:14268/api/traces",
+  //"jaegerTracesEndpoint": "http://localhost:14268/api/traces",
   "testMatrixServerUrl1": "http://localhost:11008/",
   "testMatrixServerUrl2": "http://localhost:12008/",
 
-  "Secrets": "Remove the 'xxx__' prefix and fill these in your config/config.user-overrides.json or by environment variable",
-  "xxx__matrixAccessToken": "xxx"
+  // Secrets
+  //"matrixAccessToken": "xxx"
 }

--- a/config/config.test.json
+++ b/config/config.test.json
@@ -5,6 +5,6 @@
   "testMatrixServerUrl1": "http://localhost:11008/",
   "testMatrixServerUrl2": "http://localhost:12008/",
 
-  "Secrets": "xxx",
+  // Secrets
   "matrixAccessToken": "as_token_8664700429a911bbbecf7d91b9e1a74716d669f40cf32259630e38439726e29d"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "dompurify": "^2.3.9",
         "express": "^4.17.2",
         "hydrogen-view-sdk": "npm:@mlm/hydrogen-view-sdk@^0.0.13-scratch",
+        "json5": "^2.2.1",
         "linkedom": "^0.14.1",
         "matrix-public-archive-shared": "file:./shared/",
         "nconf": "^0.11.3",
@@ -3936,6 +3937,17 @@
       "version": "1.0.1",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/json5": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
+      "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/keyv": {
       "version": "3.1.0",
@@ -8234,6 +8246,11 @@
     "json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
       "dev": true
+    },
+    "json5": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
+      "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA=="
     },
     "keyv": {
       "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "dompurify": "^2.3.9",
     "express": "^4.17.2",
     "hydrogen-view-sdk": "npm:@mlm/hydrogen-view-sdk@^0.0.13-scratch",
+    "json5": "^2.2.1",
     "linkedom": "^0.14.1",
     "matrix-public-archive-shared": "file:./shared/",
     "nconf": "^0.11.3",

--- a/server/lib/config.js
+++ b/server/lib/config.js
@@ -5,6 +5,7 @@
 
 const path = require('path');
 const nconf = require('nconf');
+const JSON5 = require('json5');
 
 function configureNodeEnv() {
   const nodeEnv = process.env.NODE_ENV;
@@ -33,14 +34,27 @@ nconf.argv().env('__');
 nconf.add('envUser', {
   type: 'file',
   file: path.join(configDir, 'config.' + nodeEnv + '.user-overrides.json'),
+  format: JSON5,
 });
 
 // Only use user-overrides in dev
 if (nodeEnv === 'dev') {
-  nconf.add('user', { type: 'file', file: path.join(configDir, 'config.user-overrides.json') });
+  nconf.add('user', {
+    type: 'file',
+    file: path.join(configDir, 'config.user-overrides.json'),
+    format: JSON5,
+  });
 }
 
-nconf.add('nodeEnv', { type: 'file', file: path.join(configDir, 'config.' + nodeEnv + '.json') });
-nconf.add('defaults', { type: 'file', file: path.join(configDir, 'config.default.json') });
+nconf.add('nodeEnv', {
+  type: 'file',
+  file: path.join(configDir, 'config.' + nodeEnv + '.json'),
+  format: JSON5,
+});
+nconf.add('defaults', {
+  type: 'file',
+  file: path.join(configDir, 'config.default.json'),
+  format: JSON5,
+});
 
 module.exports = nconf;


### PR DESCRIPTION
Use JSON5 for configuration files with comments. Now we can leave the available config in `config.default.json` without having to add weird instructions to remove the `xxx`, etc

 - https://www.npmjs.com/package/json5
 - https://www.npmjs.com/package/nconf
 - https://github.com/indexzero/nconf/issues/113#issuecomment-69999413