### PR TITLE
Make the archive responsive

### DIFF
--- a/public/styles/styles.css
+++ b/public/styles/styles.css
@@ -29,9 +29,30 @@ body {
   min-width: 0;
 }
 
+@media screen and (max-width: 800px) {
+  .ArchiveView {
+    grid-template:
+      'status' auto
+      'middle' 1fr /
+      1fr;
+  }
+
+  .ArchiveView:not(.right-shown) .RightPanelView {
+    display: none;
+  }
+
+  .ArchiveView.right-shown {
+    grid-template:
+      'status' auto
+      'right' 1fr /
+      1fr;
+  }
+  .ArchiveView.right-shown .middle {
+    display: none;
+  }
+}
+
 .CalendarView {
-  max-width: 280px;
-  font: 100% system-ui;
 }
 
 .CalendarView_header {
@@ -132,7 +153,8 @@ body {
 .CalendarView_dayLink {
   display: inline-block;
   width: 100%;
-  padding: 2px 5px;
+  padding-top: 18%;
+  padding-bottom: 18%;
 
   text-decoration: none;
 }
@@ -154,7 +176,6 @@ body {
   opacity: 0.5;
 }
 
-
 /* Error pages */
 
 .heading-sub-detail {
@@ -162,7 +183,6 @@ body {
 }
 
 .tracing-span-list {
-
 }
 
 .tracing-span-list-item {
@@ -170,7 +190,6 @@ body {
 }
 
 .tracing-span-item-http-details {
-
 }
 
 .tracing-span-item-sub-details {

--- a/public/styles/styles.css
+++ b/public/styles/styles.css
@@ -29,18 +29,30 @@ body {
   min-width: 0;
 }
 
+/* No need to open the right-panel when it's always visible at desktop widths */
+.room-header-change-dates-button {
+  display: none;
+  color: var(--icon-color--darker-20);
+}
+/* No need to close the right-panel when it's always visible at desktop widths */
+.RightPanelView_buttons .close {
+  display: none;
+}
+
 @media screen and (max-width: 800px) {
+  /* Only the middle needs to be visible mobile by default */
   .ArchiveView {
     grid-template:
       'status' auto
       'middle' 1fr /
       1fr;
   }
-
+  /* Which also means hiding the right-panel by default on mobile */
   .ArchiveView:not(.right-shown) .RightPanelView {
     display: none;
   }
 
+  /* When the user opens the right-panel, show it */
   .ArchiveView.right-shown {
     grid-template:
       'status' auto
@@ -50,10 +62,14 @@ body {
   .ArchiveView.right-shown .middle {
     display: none;
   }
-}
-
-.room-header-change-dates-button {
-  color: var(--icon-color--darker-20);
+  /* And show the button to open the right-panel on mobile */
+  .room-header-change-dates-button {
+    display: block;
+  }
+  /* And show the button to close the right-panel on mobile */
+  .RightPanelView_buttons .close {
+    display: block;
+  }
 }
 
 .CalendarView {

--- a/public/styles/styles.css
+++ b/public/styles/styles.css
@@ -52,6 +52,10 @@ body {
   }
 }
 
+.room-header-change-dates-button {
+  color: var(--icon-color--darker-20);
+}
+
 .CalendarView {
 }
 

--- a/server/routes/install-routes.js
+++ b/server/routes/install-routes.js
@@ -209,6 +209,7 @@ function installRoutes(app) {
       <!doctype html>
       <html lang="en">
         <head>
+          <meta name="viewport" content="width=device-width, initial-scale=1">
           ${sanitizeHtml(`<title>${roomData.name} - Matrix Public Archive</title>`)}
           <link href="${hydrogenStylesUrl}" rel="stylesheet">
           <link href="${stylesUrl}" rel="stylesheet">

--- a/server/routes/timeout-middleware.js
+++ b/server/routes/timeout-middleware.js
@@ -55,6 +55,7 @@ async function timeoutMiddleware(req, res, next) {
     <!doctype html>
     <html lang="en">
       <head>
+        <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>Server timeout - Matrix Public Archive</title>
         <link href="${hydrogenStylesUrl}" rel="stylesheet">
         <link href="${stylesUrl}" rel="stylesheet">

--- a/shared/4-hydrogen-vm-render-script.js
+++ b/shared/4-hydrogen-vm-render-script.js
@@ -341,7 +341,6 @@ async function mountHydrogen() {
 
     _updateRightPanel() {
       this._shouldShowRightPanel = !!this.navigation.path.get('right-panel')?.value;
-      console.log('_updateRightPanel', this._shouldShowRightPanel);
       this.emitChange('shouldShowRightPanel');
     }
   }

--- a/shared/ArchiveView.js
+++ b/shared/ArchiveView.js
@@ -2,11 +2,54 @@
 
 const {
   TemplateView,
+  AvatarView,
   RoomView,
   RightPanelView,
   LightboxView,
   viewClassForTile,
 } = require('hydrogen-view-sdk');
+
+class RoomHeaderView extends TemplateView {
+  render(t, vm) {
+    return t.div({ className: 'RoomHeader middle-header' }, [
+      t.view(new AvatarView(vm, 32)),
+      t.div({ className: 'room-description' }, [t.h2((vm) => vm.name)]),
+      t.button(
+        {
+          className: 'button-utility room-header-change-dates-button',
+          'aria-label': vm.i18n`Change dates`,
+          onClick: (/*evt*/) => {
+            vm.openRightPanel();
+          },
+        },
+        [
+          // Calendar icon (via `calendar2-date` from Bootstrap)
+          t.svg(
+            {
+              xmlns: 'http://www.w3.org/2000/svg',
+              width: '16',
+              height: '16',
+              viewBox: '0 0 16 16',
+              fill: 'currentColor',
+              style: 'vertical-align: middle;',
+            },
+            [
+              t.path({
+                d: 'M6.445 12.688V7.354h-.633A12.6 12.6 0 0 0 4.5 8.16v.695c.375-.257.969-.62 1.258-.777h.012v4.61h.675zm1.188-1.305c.047.64.594 1.406 1.703 1.406 1.258 0 2-1.066 2-2.871 0-1.934-.781-2.668-1.953-2.668-.926 0-1.797.672-1.797 1.809 0 1.16.824 1.77 1.676 1.77.746 0 1.23-.376 1.383-.79h.027c-.004 1.316-.461 2.164-1.305 2.164-.664 0-1.008-.45-1.05-.82h-.684zm2.953-2.317c0 .696-.559 1.18-1.184 1.18-.601 0-1.144-.383-1.144-1.2 0-.823.582-1.21 1.168-1.21.633 0 1.16.398 1.16 1.23z',
+              }),
+              t.path({
+                d: 'M3.5 0a.5.5 0 0 1 .5.5V1h8V.5a.5.5 0 0 1 1 0V1h1a2 2 0 0 1 2 2v11a2 2 0 0 1-2 2H2a2 2 0 0 1-2-2V3a2 2 0 0 1 2-2h1V.5a.5.5 0 0 1 .5-.5zM2 2a1 1 0 0 0-1 1v11a1 1 0 0 0 1 1h12a1 1 0 0 0 1-1V3a1 1 0 0 0-1-1H2z',
+              }),
+              t.path({
+                d: 'M2.5 4a.5.5 0 0 1 .5-.5h10a.5.5 0 0 1 .5.5v1a.5.5 0 0 1-.5.5H3a.5.5 0 0 1-.5-.5V4z',
+              }),
+            ]
+          ),
+        ]
+      ),
+    ]);
+  }
+}
 
 class ArchiveView extends TemplateView {
   render(t, vm) {
@@ -14,10 +57,15 @@ class ArchiveView extends TemplateView {
       {
         className: {
           ArchiveView: true,
+          'right-shown': (vm) => vm.shouldShowRightPanel,
         },
       },
       [
-        t.view(new RoomView(vm.roomViewModel, viewClassForTile)),
+        t.view(
+          new RoomView(vm.roomViewModel, viewClassForTile, {
+            RoomHeaderView,
+          })
+        ),
         t.view(new RightPanelView(vm.rightPanelModel)),
         t.mapView(
           (vm) => vm.lightboxViewModel,

--- a/shared/CalendarView.js
+++ b/shared/CalendarView.js
@@ -66,7 +66,7 @@ class CalendarView extends TemplateView {
                   month: 'long',
                   timeZone: 'UTC',
                 }),
-                // Drowndown arrow
+                // Dropdown arrow
                 t.svg(
                   {
                     xmlns: 'http://www.w3.org/2000/svg',

--- a/shared/CalendarView.js
+++ b/shared/CalendarView.js
@@ -66,6 +66,7 @@ class CalendarView extends TemplateView {
                   month: 'long',
                   timeZone: 'UTC',
                 }),
+                // Drowndown arrow
                 t.svg(
                   {
                     xmlns: 'http://www.w3.org/2000/svg',

--- a/shared/lib/archive-history.js
+++ b/shared/lib/archive-history.js
@@ -27,8 +27,22 @@ class ArchiveHistory extends History {
     // downstream call of `urlRouter.attach()` which we do when bootstraping
     // everything.
     if (window.history) {
-      super.replaceUrlSilently(url);
+      let replacingUrl = url;
+      // This is a way to make sure the hash gets cleared out
+      if (url === '') {
+        replacingUrl = window.location.pathname;
+      }
+      super.replaceUrlSilently(replacingUrl);
     }
+  }
+
+  pushUrlSilently(url) {
+    let replacingUrl = url;
+    // This is a way to make sure the hash gets cleared out
+    if (url === '') {
+      replacingUrl = window.location.pathname;
+    }
+    super.pushUrlSilently(replacingUrl);
   }
 
   // Make the URLs we use in the UI of the app relative to the room:


### PR DESCRIPTION
Make the archive responsive

![Responsive width archive resizing up and down](https://user-images.githubusercontent.com/558581/187547304-cf6d3355-159f-485b-98e0-2e5ab00b159f.gif)



<img src="https://user-images.githubusercontent.com/558581/187544262-f4d061ad-2b74-4fc0-9471-e71d0688763a.gif" alt="Opening and closing the right-panel" height="500px">


## Todo

 - [x] Add a way to toggle the `RightPanelView` from the `RoomHeader`
 - [x] Remove the "Close room" back button from the `RoomHeader`
 - [x] Make sure the URL changes and clears on close
 - [x] Hide the `x` icon on the right-panel when not mobile
 - [x] Hide the calendar icon at desktop widths