### PR TITLE
Better assertion error language

### DIFF
--- a/shared/lib/assert.js
+++ b/shared/lib/assert.js
@@ -3,7 +3,7 @@
 function assert(value, message) {
   console.assert(value, message);
   if (!value) {
-    throw new Error(`Assertion Error: ${value} == true`);
+    throw new Error(`AssertionError: expected ${value} to be truthy`);
   }
 }
 


### PR DESCRIPTION
Better assertion error language: `AssertionError: expected ${value} to be truthy`