### PR TITLE
Fix missing `room.observePowerLevels()` throwing error after render

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "matrix-public-archive",
       "version": "0.0.0",
+      "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/api": "^1.1.0",
         "@opentelemetry/auto-instrumentations-node": "^0.31.0",
@@ -20,7 +21,7 @@
         "@opentelemetry/semantic-conventions": "^1.3.1",
         "dompurify": "^2.3.9",
         "express": "^4.17.2",
-        "hydrogen-view-sdk": "npm:@mlm/hydrogen-view-sdk@^0.0.14-scratch",
+        "hydrogen-view-sdk": "npm:@mlm/hydrogen-view-sdk@^0.15.0-scratch",
         "json5": "^2.2.1",
         "linkedom": "^0.14.1",
         "matrix-public-archive-shared": "file:./shared/",
@@ -3636,9 +3637,9 @@
     },
     "node_modules/hydrogen-view-sdk": {
       "name": "@mlm/hydrogen-view-sdk",
-      "version": "0.0.14-scratch",
-      "resolved": "https://registry.npmjs.org/@mlm/hydrogen-view-sdk/-/hydrogen-view-sdk-0.0.14-scratch.tgz",
-      "integrity": "sha512-vH6OOOEZFeoyp25ub3fKtPWYOfN/BaY6qgxT+dpzi5zbbp7Il6eXNJgq1+Tbk5Uc5Z6E9hGlhwJ7sHwfSvvZ+A==",
+      "version": "0.15.0-scratch",
+      "resolved": "https://registry.npmjs.org/@mlm/hydrogen-view-sdk/-/hydrogen-view-sdk-0.15.0-scratch.tgz",
+      "integrity": "sha512-QRsJjk56EdMWWgSEewLOG0FgRPqP8Yyc15fyU+60GzBrSL/fh6jfkgGejLHuJbPYFcKnkPpCTDEbEDLfP2kjaQ==",
       "dependencies": {
         "@matrix-org/olm": "https://gitlab.matrix.org/api/v4/projects/27/packages/npm/@matrix-org/olm/-/@matrix-org/olm-3.2.8.tgz",
         "another-json": "^0.2.0",
@@ -8070,9 +8071,9 @@
       }
     },
     "hydrogen-view-sdk": {
-      "version": "npm:@mlm/hydrogen-view-sdk@0.0.14-scratch",
-      "resolved": "https://registry.npmjs.org/@mlm/hydrogen-view-sdk/-/hydrogen-view-sdk-0.0.14-scratch.tgz",
-      "integrity": "sha512-vH6OOOEZFeoyp25ub3fKtPWYOfN/BaY6qgxT+dpzi5zbbp7Il6eXNJgq1+Tbk5Uc5Z6E9hGlhwJ7sHwfSvvZ+A==",
+      "version": "npm:@mlm/hydrogen-view-sdk@0.15.0-scratch",
+      "resolved": "https://registry.npmjs.org/@mlm/hydrogen-view-sdk/-/hydrogen-view-sdk-0.15.0-scratch.tgz",
+      "integrity": "sha512-QRsJjk56EdMWWgSEewLOG0FgRPqP8Yyc15fyU+60GzBrSL/fh6jfkgGejLHuJbPYFcKnkPpCTDEbEDLfP2kjaQ==",
       "requires": {
         "@matrix-org/olm": "https://gitlab.matrix.org/api/v4/projects/27/packages/npm/@matrix-org/olm/-/@matrix-org/olm-3.2.8.tgz",
         "another-json": "^0.2.0",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "@opentelemetry/semantic-conventions": "^1.3.1",
     "dompurify": "^2.3.9",
     "express": "^4.17.2",
-    "hydrogen-view-sdk": "npm:@mlm/hydrogen-view-sdk@^0.0.14-scratch",
+    "hydrogen-view-sdk": "npm:@mlm/hydrogen-view-sdk@^0.15.0-scratch",
     "json5": "^2.2.1",
     "linkedom": "^0.14.1",
     "matrix-public-archive-shared": "file:./shared/",

--- a/shared/4-hydrogen-vm-render-script.js
+++ b/shared/4-hydrogen-vm-render-script.js
@@ -13,6 +13,9 @@ const {
   createRouter,
   tag,
 
+  RetainedObservableValue,
+  PowerLevels,
+
   TilesCollection,
   FragmentIdComparer,
   tileClassForEntry,
@@ -166,6 +169,22 @@ async function mountHydrogen() {
     avatarUrl: roomData.avatarUrl,
     avatarColorId: roomData.id,
     mediaRepository: mediaRepository,
+    // Based on https://github.com/vector-im/hydrogen-web/blob/5f9cfffa3b547991b665f57a8bf715270a1b2ef1/src/matrix/room/BaseRoom.js#L480
+    observePowerLevels: async function () {
+      let powerLevelsObservable = this._powerLevelsObservable;
+      if (!powerLevelsObservable) {
+        const powerLevels = new PowerLevels({
+          powerLevelEvent: {},
+          ownUserId: 'xxx-ownUserId',
+          membership: null,
+        });
+        powerLevelsObservable = new RetainedObservableValue(powerLevels, () => {
+          this._powerLevels = null;
+        });
+        this._powerLevelsObservable = powerLevelsObservable;
+      }
+      return powerLevelsObservable;
+    },
   };
 
   // Something we can modify with new state updates as we see them


### PR DESCRIPTION
Fix missing `room.observePowerLevels()` throwing error after render.

```
Uncaught (in promise) TypeError: this._room.observePowerLevels is not a function
    at RoomViewModel2._recreateComposerOnPowerLevelChange (matrix-public-archive.js:23498:53)
    at new RoomViewModel2 (matrix-public-archive.js:23469:14)
    at mountHydrogen (matrix-public-archive.js:27131:25)
    at matrix-public-archive.js:27174:1
```

Doesn't affect main-line rendering but the error is annoying to see. More Hydrogen boilerplate 😞



### Todo

 - [x] Make a release of  `@mlm/hydrogen-view-sdk` so it includes the changes from https://github.com/vector-im/hydrogen-web/pull/653