### PR TITLE
Fix `DisabledComposerView` description being overriden by powerlevel changes

### DIFF
--- a/server/routes/install-routes.js
+++ b/server/routes/install-routes.js
@@ -199,6 +199,14 @@ function installRoutes(app) {
         stateEventMap,
       });
 
+      // const _renderHydrogenToStringUnsafe = require('../hydrogen-render/3-render-hydrogen-to-string-unsafe');
+      // const hydrogenHtmlOutput = await _renderHydrogenToStringUnsafe({
+      //   fromTimestamp,
+      //   roomData,
+      //   events,
+      //   stateEventMap,
+      // });
+
       const serializableSpans = getSerializableSpans();
       const serializedSpans = JSON.stringify(serializableSpans);
 

--- a/server/routes/install-routes.js
+++ b/server/routes/install-routes.js
@@ -199,14 +199,6 @@ function installRoutes(app) {
         stateEventMap,
       });
 
-      // const _renderHydrogenToStringUnsafe = require('../hydrogen-render/3-render-hydrogen-to-string-unsafe');
-      // const hydrogenHtmlOutput = await _renderHydrogenToStringUnsafe({
-      //   fromTimestamp,
-      //   roomData,
-      //   events,
-      //   stateEventMap,
-      // });
-
       const serializableSpans = getSerializableSpans();
       const serializedSpans = JSON.stringify(serializableSpans);
 

--- a/shared/4-hydrogen-vm-render-script.js
+++ b/shared/4-hydrogen-vm-render-script.js
@@ -262,25 +262,32 @@ async function mountHydrogen() {
     this.navigation.applyPath(path);
   };
 
-  // FIXME: We shouldn't have to dive into the internal fields to make this work
-  roomViewModel._timelineVM = timelineViewModel;
+  Object.defineProperty(roomViewModel, 'timelineViewModel', {
+    get() {
+      return timelineViewModel;
+    },
+  });
   const fromDate = new Date(fromTimestamp);
   const dateString = fromDate.toISOString().split('T')[0];
-  roomViewModel._composerVM = {
-    kind: 'disabled',
-    description: [
-      `You're viewing an archive of events from ${dateString}. Use a `,
-      tag.a(
-        {
-          href: matrixPublicArchiveURLCreator.permalinkForRoomId(roomData.id),
-          rel: 'noopener',
-          target: '_blank',
-        },
-        ['Matrix client']
-      ),
-      ` to start chatting in this room.`,
-    ],
-  };
+  Object.defineProperty(roomViewModel, 'composerViewModel', {
+    get() {
+      return {
+        kind: 'disabled',
+        description: [
+          `You're viewing an archive of events from ${dateString}. Use a `,
+          tag.a(
+            {
+              href: matrixPublicArchiveURLCreator.permalinkForRoomId(roomData.id),
+              rel: 'noopener',
+              target: '_blank',
+            },
+            ['Matrix client']
+          ),
+          ` to start chatting in this room.`,
+        ],
+      };
+    },
+  });
 
   const archiveViewModel = new ArchiveViewModel({
     // Hydrogen options


### PR DESCRIPTION
Fix `DisabledComposerView` description being overriden by powerlevel changes

We added the description in https://github.com/matrix-org/matrix-public-archive/pull/54 but then made a fix to one of the after render errors, https://github.com/matrix-org/matrix-public-archive/pull/57, which exposed that the description is then overriden when the powerlevel changes.

We now just override the getters directly instead of the internal fields which are overwritten internally.

![](https://user-images.githubusercontent.com/558581/187597512-36b69e87-6dee-4b87-afd2-2e4e12a58114.png)


---

This also fixes a warning from Hydrogen in the console:

```
disposable not found, did it leak? {kind: 'disabled', description: Array(3)}
```
