### PR TITLE
Redirect to last day with message history

### DIFF
--- a/server/lib/matrix-utils/fetch-events-in-range.js
+++ b/server/lib/matrix-utils/fetch-events-in-range.js
@@ -4,6 +4,7 @@ const assert = require('assert');
 const urlJoin = require('url-join');
 
 const { fetchEndpointAsJson } = require('../fetch-endpoint');
+const timestampToEvent = require('./timestamp-to-event');
 const { traceFunction } = require('../../tracing/trace-utilities');
 
 const config = require('../config');
@@ -27,14 +28,12 @@ async function fetchEventsFromTimestampBackwards(accessToken, roomId, ts, limit)
   assert(ts);
   assert(limit);
 
-  const timestampToEventEndpoint = urlJoin(
-    matrixServerUrl,
-    `_matrix/client/unstable/org.matrix.msc3030/rooms/${roomId}/timestamp_to_event?ts=${ts}&dir=b`
-  );
-  const timestampToEventResData = await fetchEndpointAsJson(timestampToEventEndpoint, {
+  const { eventId: eventIdForTimestamp } = await timestampToEvent({
     accessToken,
+    roomId,
+    ts,
+    direction: 'b',
   });
-  const eventIdForTimestamp = timestampToEventResData.event_id;
   assert(eventIdForTimestamp);
   //console.log('eventIdForTimestamp', eventIdForTimestamp);
 

--- a/server/lib/matrix-utils/fetch-public-rooms.js
+++ b/server/lib/matrix-utils/fetch-public-rooms.js
@@ -28,7 +28,6 @@ async function fetchPublicRooms(accessToken, { server, paginationToken, limit } 
     matrixServerUrl,
     `_matrix/client/v3/publicRooms?${qs.toString()}`
   );
-  console.log('publicRoomsEndpoint', publicRoomsEndpoint);
 
   const publicRoomsRes = await fetchEndpointAsJson(publicRoomsEndpoint, {
     accessToken,

--- a/server/lib/matrix-utils/timestamp-to-event.js
+++ b/server/lib/matrix-utils/timestamp-to-event.js
@@ -1,0 +1,33 @@
+'use strict';
+
+const assert = require('assert');
+const urlJoin = require('url-join');
+
+const { fetchEndpointAsJson } = require('../fetch-endpoint');
+const { traceFunction } = require('../../tracing/trace-utilities');
+
+const config = require('../config');
+const matrixServerUrl = config.get('matrixServerUrl');
+assert(matrixServerUrl);
+
+async function timestampToEvent({ accessToken, roomId, ts, direction }) {
+  assert(accessToken);
+  assert(roomId);
+  assert(ts);
+  assert(direction);
+
+  const timestampToEventEndpoint = urlJoin(
+    matrixServerUrl,
+    `_matrix/client/unstable/org.matrix.msc3030/rooms/${roomId}/timestamp_to_event?ts=${ts}&dir=${direction}`
+  );
+  const timestampToEventResData = await fetchEndpointAsJson(timestampToEventEndpoint, {
+    accessToken,
+  });
+
+  return {
+    eventId: timestampToEventResData.event_id,
+    originServerTs: timestampToEventResData.origin_server_ts,
+  };
+}
+
+module.exports = traceFunction(timestampToEvent);

--- a/server/routes/room-routes.js
+++ b/server/routes/room-routes.js
@@ -12,7 +12,9 @@ const timeoutMiddleware = require('./timeout-middleware');
 const fetchRoomData = require('../lib/matrix-utils/fetch-room-data');
 const fetchEventsInRange = require('../lib/matrix-utils/fetch-events-in-range');
 const ensureRoomJoined = require('../lib/matrix-utils/ensure-room-joined');
+const timestampToEvent = require('../lib/matrix-utils/timestamp-to-event');
 const renderHydrogenVmRenderScriptToPageHtml = require('../hydrogen-render/render-hydrogen-vm-render-script-to-page-html');
+const MatrixPublicArchiveURLCreator = require('matrix-public-archive-shared/lib/url-creator');
 
 const config = require('../lib/config');
 const basePath = config.get('basePath');
@@ -23,6 +25,8 @@ const matrixAccessToken = config.get('matrixAccessToken');
 assert(matrixAccessToken);
 const archiveMessageLimit = config.get('archiveMessageLimit');
 assert(archiveMessageLimit);
+
+const matrixPublicArchiveURLCreator = new MatrixPublicArchiveURLCreator(basePath);
 
 const router = express.Router({
   caseSensitive: true,
@@ -72,6 +76,40 @@ function parseArchiveRangeFromReq(req) {
     toHour,
   };
 }
+
+router.get(
+  '/',
+  asyncHandler(async function (req, res) {
+    const roomIdOrAlias = req.params.roomIdOrAlias;
+    assert(roomIdOrAlias.startsWith('!') || roomIdOrAlias.startsWith('#'));
+
+    // In case we're joining a new room for the first time,
+    // let's avoid redirecting to our join event
+    const dateBeforeJoin = Date.now();
+
+    // We have to wait for the room join to happen first before we can fetch
+    // any of the additional room info or messages.
+    await ensureRoomJoined(matrixAccessToken, roomIdOrAlias, req.query.via);
+
+    // Find the closest day to today with messages
+    const { originServerTs } = await timestampToEvent({
+      accessToken: matrixAccessToken,
+      roomId: roomIdOrAlias,
+      ts: dateBeforeJoin,
+      direction: 'b',
+    });
+    if (!originServerTs) {
+      throw new StatusError(404, 'Unable to find day with an event');
+    }
+
+    // Redirect to a day with messages
+    res.redirect(
+      matrixPublicArchiveURLCreator.archiveUrlForDate(roomIdOrAlias, new Date(originServerTs), {
+        viaServers: req.query.via,
+      })
+    );
+  })
+);
 
 router.get(
   '/event/:eventId',

--- a/server/routes/room-routes.js
+++ b/server/routes/room-routes.js
@@ -99,7 +99,7 @@ router.get(
       direction: 'b',
     });
     if (!originServerTs) {
-      throw new StatusError(404, 'Unable to find day with an event');
+      throw new StatusError(404, 'Unable to find day with an history');
     }
 
     // Redirect to a day with messages


### PR DESCRIPTION
Redirect to last day with message history: `/:roomIdOrAlias` -> `/:roomIdOrAlias/date/:yyyy/:mm/:dd`

Fix https://github.com/matrix-org/matrix-public-archive/issues/60