### PR TITLE
Sanity check that we are not leaking the access token to the client

### DIFF
--- a/server/hydrogen-render/render-hydrogen-to-string.js
+++ b/server/hydrogen-render/render-hydrogen-to-string.js
@@ -18,8 +18,8 @@ async function renderHydrogenToString(renderOptions) {
   assert(renderOptions.vmRenderScriptFilePath);
   assert(renderOptions.vmRenderContext);
 
-  // We expect config but we should sanity check that we aren't leaking the access token
-  // to the client
+  // We expect `config` but we should sanity check that we aren't leaking the access token
+  // to the client if someone naievely copied the whole `config` object to here.
   assert(renderOptions.vmRenderContext.config);
   assert(
     !renderOptions.vmRenderContext.config.matrixAccessToken,

--- a/server/hydrogen-render/render-hydrogen-to-string.js
+++ b/server/hydrogen-render/render-hydrogen-to-string.js
@@ -18,6 +18,14 @@ async function renderHydrogenToString(renderOptions) {
   assert(renderOptions.vmRenderScriptFilePath);
   assert(renderOptions.vmRenderContext);
 
+  // We expect config but we should sanity check that we aren't leaking the access token
+  // to the client
+  assert(renderOptions.vmRenderContext.config);
+  assert(
+    !renderOptions.vmRenderContext.config.matrixAccessToken,
+    'We should not be leaking the `matrixAccessToken` to the Hydrogen render function because this will reach the client!'
+  );
+
   try {
     // In development, if you're running into a hard to track down error with
     // the render hydrogen stack and fighting against the multiple layers of

--- a/server/hydrogen-render/render-hydrogen-to-string.js
+++ b/server/hydrogen-render/render-hydrogen-to-string.js
@@ -23,7 +23,7 @@ async function renderHydrogenToString(renderOptions) {
   assert(renderOptions.vmRenderContext.config);
   assert(
     !renderOptions.vmRenderContext.config.matrixAccessToken,
-    'We should not be leaking the `matrixAccessToken` to the Hydrogen render function because this will reach the client!'
+    'We should not be leaking the `config.matrixAccessToken` to the Hydrogen render function because this will reach the client!'
   );
 
   try {


### PR DESCRIPTION
Sanity check that we are not leaking the access token to the client.

This isn't spawning from any previous security issue. Just adding an extra check to help ensure we don't ever regress this in the future.

```
AssertionError [ERR_ASSERTION]: We should not be leaking the `config.matrixAccessToken` to the Hydrogen render function because this will reach the client!
    at renderHydrogenToString (matrix-public-archive\server\hydrogen-render\render-hydrogen-to-string.js:24:3)
    at renderHydrogenVmRenderScriptToPageHtml (matrix-public-archive\server\hydrogen-render\render-hydrogen-vm-render-script-to-page-html.js:22:36)
    at matrix-public-archive\server\routes\room-directory-routes.js:53:28
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
```