### PR TITLE
Fix wrong path to Hydrogen styles on timeout error page

### DIFF
--- a/server/routes/timeout-middleware.js
+++ b/server/routes/timeout-middleware.js
@@ -48,7 +48,7 @@ async function timeoutMiddleware(req, res, next) {
       humanReadableSpans = [noTracingDataAvailableItem];
     }
 
-    const hydrogenStylesUrl = urlJoin(basePath, '/css/hydrogen-styles.css');
+    const hydrogenStylesUrl = urlJoin(basePath, '/hydrogen-styles.css');
     const stylesUrl = urlJoin(basePath, '/css/styles.css');
 
     const pageHtml = `


### PR DESCRIPTION
Fix wrong path to Hydrogen styles on timeout error page.

Regressed in https://github.com/matrix-org/matrix-public-archive/pull/61 where we tried to serve this under `/css/hydrogen-styles.css` but it doesn't work because all of the image and font references in the CSS file expect it to be at the domain root so just reverted back to serving at the root `/`.