### PR TITLE
Throw more understandable error when we fail to fetch from the homeserver room directory

### DIFF
--- a/server/routes/room-directory-routes.js
+++ b/server/routes/room-directory-routes.js
@@ -6,6 +6,7 @@ const urlJoin = require('url-join');
 const express = require('express');
 const asyncHandler = require('../lib/express-async-handler');
 
+const RethrownError = require('../lib/rethrown-error');
 const fetchPublicRooms = require('../lib/matrix-utils/fetch-public-rooms');
 const renderHydrogenVmRenderScriptToPageHtml = require('../hydrogen-render/render-hydrogen-vm-render-script-to-page-html');
 
@@ -31,19 +32,26 @@ router.get(
     const paginationToken = req.query.page;
     const searchTerm = req.query.search;
 
-    const { rooms, nextPaginationToken, prevPaginationToken } = await fetchPublicRooms(
-      matrixAccessToken,
-      {
-        //server: TODO,
-        searchTerm,
-        paginationToken,
-        // It would be good to grab more rooms than we display in case we need
-        // to filter any out but then the pagination tokens with the homeserver
-        // will be out of sync. XXX: It would be better if we could just filter
-        // `/publicRooms` directly via the API (needs MSC).
-        limit: 9,
-      }
-    );
+    let rooms;
+    let nextPaginationToken;
+    let prevPaginationToken;
+    try {
+      ({ rooms, nextPaginationToken, prevPaginationToken } = await fetchPublicRooms(
+        matrixAccessToken,
+        {
+          //server: TODO,
+          searchTerm,
+          paginationToken,
+          // It would be good to grab more rooms than we display in case we need
+          // to filter any out but then the pagination tokens with the homeserver
+          // will be out of sync. XXX: It would be better if we could just filter
+          // `/publicRooms` directly via the API (needs MSC).
+          limit: 9,
+        }
+      ));
+    } catch (err) {
+      throw new RethrownError(`Unable to fetch rooms from room directory`, err);
+    }
 
     const hydrogenStylesUrl = urlJoin(basePath, '/hydrogen-styles.css');
     const stylesUrl = urlJoin(basePath, '/css/styles.css');

--- a/server/routes/room-directory-routes.js
+++ b/server/routes/room-directory-routes.js
@@ -32,6 +32,12 @@ router.get(
     const paginationToken = req.query.page;
     const searchTerm = req.query.search;
 
+    // It would be good to grab more rooms than we display in case we need
+    // to filter any out but then the pagination tokens with the homeserver
+    // will be out of sync. XXX: It would be better if we could just filter
+    // `/publicRooms` directly via the API (needs MSC).
+    const limit = 9;
+
     let rooms;
     let nextPaginationToken;
     let prevPaginationToken;
@@ -42,15 +48,14 @@ router.get(
           //server: TODO,
           searchTerm,
           paginationToken,
-          // It would be good to grab more rooms than we display in case we need
-          // to filter any out but then the pagination tokens with the homeserver
-          // will be out of sync. XXX: It would be better if we could just filter
-          // `/publicRooms` directly via the API (needs MSC).
-          limit: 9,
+          limit,
         }
       ));
     } catch (err) {
-      throw new RethrownError(`Unable to fetch rooms from room directory`, err);
+      throw new RethrownError(
+        `Unable to fetch rooms from room directory (homeserver=${matrixServerUrl})\n    searchTerm=${searchTerm}, paginationToken=${paginationToken}, limit=${limit}`,
+        err
+      );
     }
 
     const hydrogenStylesUrl = urlJoin(basePath, '/hydrogen-styles.css');


### PR DESCRIPTION
Throw more understandable error when we fail to fetch from the homeserver room directory

Fix https://github.com/matrix-org/matrix-public-archive/issues/80

```
RethrownError: Unable to fetch rooms from room directory (homeserver=http://localhost:8008/)
    searchTerm=, paginationToken=undefined, limit=9
    at matrix-public-archive\server\routes\room-directory-routes.js:55:13
    --- Original Error ---
    Error: HTTP Error Response: 500 Internal Server Error: {"errcode":"M_UNKNOWN","error":"Internal server error"}
        URL=http://localhost:8008/_matrix/client/v3/publicRooms?
        at checkResponseStatus (matrix-public-archive\server\lib\fetch-endpoint.js:21:11)
        at processTicksAndRejections (node:internal/process/task_queues:96:5)
        at async fetchEndpoint (matrix-public-archive\server\lib\fetch-endpoint.js:38:3)
        at async fetchEndpointAsJson (matrix-public-archive\server\lib\fetch-endpoint.js:63:15)
        at async fetchPublicRooms (matrix-public-archive\server\lib\matrix-utils\fetch-public-rooms.js:26:26)
        at async matrix-public-archive\server\tracing\trace-utilities.js:31:24
        at async matrix-public-archive\server\routes\room-directory-routes.js:45:62
```