### PR TITLE
Have full room description readable from tooltip

### DIFF
--- a/shared/views/RoomCardView.js
+++ b/shared/views/RoomCardView.js
@@ -70,7 +70,7 @@ class RoomCardView extends TemplateView {
           },
           [aliasOrRoomId]
         ),
-        t.p({ className: 'RoomCardView_topic' }, [vm.topic || '']),
+        t.p({ className: 'RoomCardView_topic', title: vm.topic || null }, [vm.topic || '']),
         t.div({ className: 'RoomCardView_footer' }, [
           t.div({ className: 'RoomCardView_footerInner' }, [
             t.div({}, [memberDisplay]),


### PR DESCRIPTION
The `RoomCard`  clips text two lines before ellipsing. This will make the rest of the description readable if you hover over the description.