### PR TITLE
Fix off-by-one calendar months with time zones that are greater than UTC+0

### DIFF
--- a/shared/views/CalendarView.js
+++ b/shared/views/CalendarView.js
@@ -21,9 +21,9 @@ function numDaysInMonthForDate(inputDate) {
   const lastDayOfTheMonthDate = new Date(
     Date.UTC(inputDate.getUTCFullYear(), inputDate.getUTCMonth() + 1, 0)
   );
-  const lastDayOfTheMonth = lastDayOfTheMonthDate.getUTCDate();
-  // The last day in the month is a proxy for how many days there are in that month
-  return lastDayOfTheMonth;
+  const lastDayNumberOfTheMonth = lastDayOfTheMonthDate.getUTCDate();
+  // The last day number in the month is a proxy for how many days there are in that month
+  return lastDayNumberOfTheMonth;
 }
 
 // Map from day of week to the localized name of the day

--- a/shared/views/CalendarView.js
+++ b/shared/views/CalendarView.js
@@ -18,10 +18,20 @@ function sameDay(date1, date2) {
 //
 // via https://stackoverflow.com/a/1184359/796832
 function numDaysInMonthForDate(inputDate) {
+  console.log('------------------------------------');
+  console.log('inputDate', inputDate.toUTCString(), new Date(inputDate).getTime());
   const lastDayOfTheMonthDate = new Date(
-    Date.UTC(inputDate.getUTCFullYear(), inputDate.getUTCMonth() + 1, 0)
+    inputDate.getUTCFullYear(),
+    inputDate.getUTCMonth() + 1,
+    0
+  );
+  console.log(
+    'lastDayOfTheMonthDate',
+    lastDayOfTheMonthDate.toUTCString(),
+    new Date(lastDayOfTheMonthDate).getTime()
   );
   const lastDayOfTheMonth = lastDayOfTheMonthDate.getUTCDate();
+  console.log('lastDayOfTheMonth', lastDayOfTheMonth);
   // The last day in the month is a proxy for how many days there are in that month
   return lastDayOfTheMonth;
 }

--- a/shared/views/CalendarView.js
+++ b/shared/views/CalendarView.js
@@ -17,8 +17,13 @@ function sameDay(date1, date2) {
 // month.
 //
 // via https://stackoverflow.com/a/1184359/796832
-function numDaysInMonthForDate(date) {
-  return new Date(date.getUTCFullYear(), date.getUTCMonth() + 1, 0).getUTCDate();
+function numDaysInMonthForDate(inputDate) {
+  const lastDayOfTheMonthDate = new Date(
+    Date.UTC(inputDate.getUTCFullYear(), inputDate.getUTCMonth() + 1, 0)
+  );
+  const lastDayOfTheMonth = lastDayOfTheMonthDate.getUTCDate();
+  // The last day in the month is a proxy for how many days there are in that month
+  return lastDayOfTheMonth;
 }
 
 // Map from day of week to the localized name of the day
@@ -147,9 +152,10 @@ class CalendarView extends TemplateView {
               }),
               (() => {
                 const todayTs = Date.now();
+                const numberOfDaysInMonth = numDaysInMonthForDate(calendarDate);
 
                 let dayNodes = [];
-                for (let i = 0; i < numDaysInMonthForDate(calendarDate); i++) {
+                for (let i = 0; i < numberOfDaysInMonth; i++) {
                   const dayNumberDate = new Date(calendarDate);
                   // Date is a 1-based number
                   dayNumberDate.setUTCDate(i + 1);

--- a/shared/views/CalendarView.js
+++ b/shared/views/CalendarView.js
@@ -18,20 +18,10 @@ function sameDay(date1, date2) {
 //
 // via https://stackoverflow.com/a/1184359/796832
 function numDaysInMonthForDate(inputDate) {
-  console.log('------------------------------------');
-  console.log('inputDate', inputDate.toUTCString(), new Date(inputDate).getTime());
   const lastDayOfTheMonthDate = new Date(
-    inputDate.getUTCFullYear(),
-    inputDate.getUTCMonth() + 1,
-    0
-  );
-  console.log(
-    'lastDayOfTheMonthDate',
-    lastDayOfTheMonthDate.toUTCString(),
-    new Date(lastDayOfTheMonthDate).getTime()
+    Date.UTC(inputDate.getUTCFullYear(), inputDate.getUTCMonth() + 1, 0)
   );
   const lastDayOfTheMonth = lastDayOfTheMonthDate.getUTCDate();
-  console.log('lastDayOfTheMonth', lastDayOfTheMonth);
   // The last day in the month is a proxy for how many days there are in that month
   return lastDayOfTheMonth;
 }

--- a/shared/views/CalendarView.js
+++ b/shared/views/CalendarView.js
@@ -12,12 +12,12 @@ function sameDay(date1, date2) {
   );
 }
 
-// Month in JavaScript is 0-indexed (January is 0, February is 1, etc),
-// but by using 0 as the day it will give us the last day of the prior
-// month.
+// Get the number of days in the given month where the `inputDate` lies.
 //
 // via https://stackoverflow.com/a/1184359/796832
 function numDaysInMonthForDate(inputDate) {
+  // Month in JavaScript is 0-indexed (January is 0, February is 1, etc),
+  // but by using 0 as the day it will give us the last day of the prior
   const lastDayOfTheMonthDate = new Date(
     Date.UTC(inputDate.getUTCFullYear(), inputDate.getUTCMonth() + 1, 0)
   );


### PR DESCRIPTION
Fix off-by-one calendar months with time zones that are greater than UTC+0 (GMT+0).

Fix https://github.com/matrix-org/matrix-public-archive/issues/77

Previously, we would calculate `lastDayOfTheMonthDate` in the local timezone because we were using the vanilla `new Date(year, month, 0)` constructor. For any timezone greater than `UTC+0` (like London UTC+1 or Korea UTC +9), this means that the date is a day-behind when we go back to UTC+0.

**Before:**

```
inputDate Fri, 29 Jul 2022 00:00:00 GMT 1659052800000
lastDayOfTheMonthDate Sat, 30 Jul 2022 23:00:00 GMT 1659222000000
lastDayOfTheMonth 30
```

**After**

```
inputDate Fri, 29 Jul 2022 00:00:00 GMT 1659052800000
lastDayOfTheMonthDate Sun, 31 Jul 2022 00:00:00 GMT 1659225600000
lastDayOfTheMonth 31
```



### Dev notes

It would be nice to be able to detect `Date` mis uses. We need to be careful to always use the UTC version of all of the date functions.

Can we carefully lint away usages of certain `Date` functions? We only want to allow `new Date(value)` with an integer (kinda seems like we need TypeScript for that) and related UTC member functions.

We definitely want to dis-allow [`new Date(year, monthIndex, day)` type constructors](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/Date) and any string parsing like `Date.parse(...)` and `new Date(dateString)` where the timezone can be assumed if it's not specified.


Random cool thought: Use [`semgrep`](https://github.com/returntocorp/semgrep) to find `Date` usages where we don't first use UTC stuff, etc