### PR TITLE
Add homeserver selector to room directory landing page

### DIFF
--- a/public/css/room-directory.css
+++ b/public/css/room-directory.css
@@ -119,11 +119,35 @@
 
 .RoomDirectoryView_homeserverSelectSection {
   display: flex;
+  align-items: center;
   margin-top: 16px;
 }
 
 .RoomDirectoryView_homeserverSelector {
   margin-left: 1ch;
+  padding: 2px 6px;
+  padding-right: 2px;
+
+  background: rgba(255, 255, 255, 0.2);
+  border-radius: 4px;
+  border: 2px solid transparent;
+
+  transition: border-color 0.2s ease;
+
+  color: #ffffff;
+}
+
+.RoomDirectoryView_homeserverSelector:hover {
+  border: 2px solid rgba(213, 231, 246, 0.3);
+}
+
+.RoomDirectoryView_homeserverSelector:focus {
+  border: 2px solid rgba(213, 231, 246, 0.5);
+  outline: none;
+}
+
+.RoomDirectoryView_homeserverSelector > option {
+  color: initial;
 }
 
 .RoomDirectoryView_mainContent {

--- a/server/lib/matrix-utils/fetch-public-rooms.js
+++ b/server/lib/matrix-utils/fetch-public-rooms.js
@@ -26,6 +26,7 @@ async function fetchPublicRooms(accessToken, { server, searchTerm, paginationTok
   const publicRoomsRes = await fetchEndpointAsJson(publicRoomsEndpoint, {
     method: 'POST',
     body: {
+      include_all_networks: true,
       filter: {
         generic_search_term: searchTerm,
       },

--- a/server/routes/room-directory-routes.js
+++ b/server/routes/room-directory-routes.js
@@ -31,6 +31,7 @@ router.get(
   asyncHandler(async function (req, res) {
     const paginationToken = req.query.page;
     const searchTerm = req.query.search;
+    const homeserver = req.query.homeserver;
 
     // It would be good to grab more rooms than we display in case we need
     // to filter any out but then the pagination tokens with the homeserver
@@ -45,7 +46,7 @@ router.get(
       ({ rooms, nextPaginationToken, prevPaginationToken } = await fetchPublicRooms(
         matrixAccessToken,
         {
-          //server: TODO,
+          server: homeserver,
           searchTerm,
           paginationToken,
           limit,
@@ -53,7 +54,7 @@ router.get(
       ));
     } catch (err) {
       throw new RethrownError(
-        `Unable to fetch rooms from room directory (homeserver=${matrixServerUrl})\n    searchTerm=${searchTerm}, paginationToken=${paginationToken}, limit=${limit}`,
+        `Unable to fetch rooms from room directory (using matrixServerUrl=${matrixServerUrl})\n    homeserver=${homeserver}, searchTerm=${searchTerm}, paginationToken=${paginationToken}, limit=${limit}`,
         err
       );
     }


### PR DESCRIPTION
Add homeserver selector to room directory landing page. Opting for the simple solution and using `include_all_networks` instead needing to fetch the information about the third-party networks.

Fix https://github.com/matrix-org/matrix-public-archive/issues/6


## Dev notes

Homeserver selector in the room directory view in Element:
![](https://user-images.githubusercontent.com/558581/196576711-7d41d4e0-5cce-4612-ad28-d95f010a65a8.png)
