### PR TITLE
Improve performance of scrolling on room directory (animating gradient and shadow header)

### DIFF
--- a/public/css/room-directory.css
+++ b/public/css/room-directory.css
@@ -3,6 +3,9 @@
 }
 
 .RoomDirectoryView_header {
+  overflow: hidden;
+  display: flex;
+  justify-content: center;
   padding-left: 10px;
   padding-bottom: 80px;
   padding-right: 10px;
@@ -34,16 +37,18 @@
 }
 
 .RoomDirectoryView_headerForm {
-  display: flex;
+  display: inline-flex;
   flex-direction: column;
   align-items: center;
   padding-top: 80px;
 
-  /* Based on https://css-tricks.com/make-a-smooth-shadow-friend/ */
-  filter: drop-shadow(0 2.8px 2.2px rgba(0, 0, 0, 0.034))
-    drop-shadow(0 6.7px 5.3px rgba(0, 0, 0, 0.048)) drop-shadow(0 12.5px 10px rgba(0, 0, 0, 0.06))
-    drop-shadow(0 22.3px 17.9px rgba(0, 0, 0, 0.072))
-    drop-shadow(0 41.8px 33.4px rgba(0, 0, 0, 0.086)) drop-shadow(0 100px 80px rgba(0, 0, 0, 0.12));
+  filter: drop-shadow(0 8px 16px rgba(0, 0, 0, 0.25));
+
+  /* We're not changing transform on this element but this hints the browser to create a
+   * new layer which will be much easier to composite on top of our animating background.
+   * Related: https://web.dev/animations-guide/#force
+   */
+  will-change: transform;
 }
 
 .RoomDirectoryView_matrixLogo {


### PR DESCRIPTION
Improve performance of scrolling on room directory (animating gradient and shadow header).

 1. Dumbs down the drop shadow to not be as intensive (really helps performance)
 1. Put the header content on its own layer above the animating background which is probably easier for the browser to composite together
 1. Make the bounds of the header contents smaller so the layer is smaller
 1. Specifying `overflow: hidden;` on the header seemed to be an extra gain probably because the drop shadows were really spilling over before
 
Before, I experienced laggy stutter on mobile (Pixel 4a) and even on a Macbook Pro. Was fine on a chonky desktop computer with GPU though 😁

Now it seems buttery smooth ⏩