### PR TITLE
Load room directory and show error message when we're unable to fetch rooms

### DIFF
--- a/public/css/room-directory.css
+++ b/public/css/room-directory.css
@@ -222,12 +222,29 @@
   margin-bottom: 0;
 }
 
+.RoomDirectoryView_roomListError {
+  display: block;
+  width: 100%;
+  max-width: 1180px;
+  padding-left: 20px;
+  padding-right: 20px;
+  margin-top: 20px;
+
+  line-height: 1.5;
+}
+
 @media (min-width: 750px) {
   .RoomDirectoryView_roomList {
     grid-template-columns: repeat(2, 1fr);
+    margin-top: 40px;
     padding-left: 40px;
     padding-right: 40px;
+  }
+
+  .RoomDirectoryView_roomListError {
     margin-top: 40px;
+    padding-left: 40px;
+    padding-right: 40px;
   }
 }
 

--- a/public/css/room-directory.css
+++ b/public/css/room-directory.css
@@ -233,6 +233,13 @@
   line-height: 1.5;
 }
 
+.RoomDirectoryView_codeBlock {
+  overflow: auto;
+  background-color: #f6f6f6;
+  border: 1px solid rgb(233, 233, 233);
+  padding: 0.5em 0.8em;
+}
+
 @media (min-width: 750px) {
   .RoomDirectoryView_roomList {
     grid-template-columns: repeat(2, 1fr);

--- a/public/css/room-directory.css
+++ b/public/css/room-directory.css
@@ -235,9 +235,11 @@
 
 .RoomDirectoryView_codeBlock {
   overflow: auto;
+  padding: 0.5em 0.8em;
+
   background-color: #f6f6f6;
   border: 1px solid rgb(233, 233, 233);
-  padding: 0.5em 0.8em;
+  border-radius: 4px;
 }
 
 @media (min-width: 750px) {

--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -12,6 +12,32 @@ body {
   margin: 0;
 }
 
+summary {
+  cursor: pointer;
+}
+
+.PrimaryActionButton {
+  display: inline-block;
+  padding: 4px 16px;
+
+  background-color: transparent;
+  /* Always make a pill shape */
+  border-radius: 9999px;
+  border: 1px solid #2774c2;
+
+  color: #2774c2;
+  line-height: 24px;
+  text-decoration: none;
+
+  cursor: pointer;
+}
+
+.PrimaryActionButton:hover,
+.PrimaryActionButton:focus {
+  background-color: #2774c2;
+  color: #ffffff;
+}
+
 /* Based on .SessionView from Hydrogen */
 .ArchiveRoomView {
   /* this takes into account whether or not the url bar is hidden on mobile
@@ -319,28 +345,6 @@ body {
   display: flex;
   justify-content: flex-end;
   margin-top: 16px;
-}
-
-.ModalView_actionButton {
-  display: inline-block;
-  padding: 4px 16px;
-
-  background-color: transparent;
-  /* Always make a pill shape */
-  border-radius: 9999px;
-  border: 1px solid #2774c2;
-
-  color: #2774c2;
-  line-height: 24px;
-  text-decoration: none;
-
-  cursor: pointer;
-}
-
-.ModalView_actionButton:hover,
-.ModalView_actionButton:focus {
-  background-color: #2774c2;
-  color: #ffffff;
 }
 
 /* Developer options modal */

--- a/server/routes/room-directory-routes.js
+++ b/server/routes/room-directory-routes.js
@@ -65,10 +65,12 @@ router.get(
       path.resolve(__dirname, '../../shared/room-directory-vm-render-script.js'),
       {
         rooms,
-        roomFetchError: {
-          message: roomFetchError.message,
-          stack: roomFetchError.stack,
-        },
+        roomFetchError: roomFetchError
+          ? {
+              message: roomFetchError.message,
+              stack: roomFetchError.stack,
+            }
+          : null,
         nextPaginationToken,
         prevPaginationToken,
         searchParameters: {

--- a/server/routes/room-directory-routes.js
+++ b/server/routes/room-directory-routes.js
@@ -6,7 +6,6 @@ const urlJoin = require('url-join');
 const express = require('express');
 const asyncHandler = require('../lib/express-async-handler');
 
-const RethrownError = require('../lib/rethrown-error');
 const fetchPublicRooms = require('../lib/matrix-utils/fetch-public-rooms');
 const renderHydrogenVmRenderScriptToPageHtml = require('../hydrogen-render/render-hydrogen-vm-render-script-to-page-html');
 
@@ -43,7 +42,6 @@ router.get(
     let nextPaginationToken;
     let prevPaginationToken;
     let roomFetchError;
-    let roomFetchUnderlyingError;
     try {
       ({ rooms, nextPaginationToken, prevPaginationToken } = await fetchPublicRooms(
         matrixAccessToken,
@@ -55,7 +53,7 @@ router.get(
         }
       ));
     } catch (err) {
-      roomFetchUnderlyingError = err;
+      roomFetchError = err;
     }
 
     const hydrogenStylesUrl = urlJoin(basePath, '/hydrogen-styles.css');
@@ -68,8 +66,8 @@ router.get(
       {
         rooms,
         roomFetchError: {
-          message: roomFetchUnderlyingError.message,
-          stack: roomFetchUnderlyingError.stack,
+          message: roomFetchError.message,
+          stack: roomFetchError.stack,
         },
         nextPaginationToken,
         prevPaginationToken,

--- a/shared/room-directory-vm-render-script.js
+++ b/shared/room-directory-vm-render-script.js
@@ -17,9 +17,10 @@ const RoomDirectoryViewModel = require('matrix-public-archive-shared/viewmodels/
 
 const rooms = window.matrixPublicArchiveContext.rooms;
 assert(rooms);
+const roomFetchError = window.matrixPublicArchiveContext.roomFetchError;
 const nextPaginationToken = window.matrixPublicArchiveContext.nextPaginationToken;
 const prevPaginationToken = window.matrixPublicArchiveContext.prevPaginationToken;
-const searchTerm = window.matrixPublicArchiveContext.searchTerm;
+const searchParameters = window.matrixPublicArchiveContext.searchParameters;
 const config = window.matrixPublicArchiveContext.config;
 assert(config);
 assert(config.matrixServerUrl);
@@ -78,7 +79,8 @@ async function mountHydrogen() {
     homeserverName: config.matrixServerName,
     matrixPublicArchiveURLCreator,
     rooms,
-    searchTerm,
+    roomFetchError,
+    searchParameters,
     nextPaginationToken,
     prevPaginationToken,
   });

--- a/shared/viewmodels/RoomDirectoryViewModel.js
+++ b/shared/viewmodels/RoomDirectoryViewModel.js
@@ -19,7 +19,8 @@ class RoomDirectoryViewModel extends ViewModel {
       homeserverName,
       matrixPublicArchiveURLCreator,
       rooms,
-      searchTerm,
+      roomFetchError,
+      searchParameters,
       nextPaginationToken,
       prevPaginationToken,
     } = options;
@@ -27,6 +28,8 @@ class RoomDirectoryViewModel extends ViewModel {
     assert(homeserverName);
     assert(matrixPublicArchiveURLCreator);
     assert(rooms);
+
+    this._roomFetchError = roomFetchError;
 
     this._homeserverUrl = homeserverUrl;
     this._homeserverName = homeserverName;
@@ -45,7 +48,9 @@ class RoomDirectoryViewModel extends ViewModel {
         };
       })
     );
-    this._searchTerm = searchTerm;
+
+    this._searchParameters = searchParameters;
+    this._searchTerm = searchParameters.searchTerm;
     this._addedHomeserversList = [];
     this._nextPaginationToken = nextPaginationToken;
     this._prevPaginationToken = prevPaginationToken;
@@ -92,8 +97,16 @@ class RoomDirectoryViewModel extends ViewModel {
     return this._homeserverUrl;
   }
 
+  get homeserverName() {
+    return this._homeserverName;
+  }
+
   get roomDirectoryUrl() {
     return this._matrixPublicArchiveURLCreator.roomDirectoryUrl();
+  }
+
+  get searchParameters() {
+    return this._searchParameters;
   }
 
   get searchTerm() {
@@ -179,6 +192,10 @@ class RoomDirectoryViewModel extends ViewModel {
     const addedHomeserversList = this.addedHomeserversList;
     this.setAddedHomeserversList(addedHomeserversList.concat(newHomeserver));
     this.setHomeserverSelection(newHomeserver);
+  }
+
+  get roomFetchError() {
+    return this._roomFetchError;
   }
 
   get nextPageUrl() {

--- a/shared/views/HomeserverSelectionModalContentView.js
+++ b/shared/views/HomeserverSelectionModalContentView.js
@@ -24,7 +24,7 @@ class HomeserverSelectionModalContentView extends TemplateView {
             t.p(['Enter the name of a new server you want to explore.']),
             serverNameInput,
             t.footer({ className: 'ModalView_footerActionBar' }, [
-              t.button({ className: 'ModalView_actionButton' }, 'Add'),
+              t.button({ className: 'PrimaryActionButton' }, 'Add'),
             ]),
           ]),
         ]

--- a/shared/views/RoomDirectoryView.js
+++ b/shared/views/RoomDirectoryView.js
@@ -168,6 +168,62 @@ class RoomDirectoryView extends TemplateView {
       [
         t.header({ className: 'RoomDirectoryView_header' }, [headerForm]),
         t.main({ className: 'RoomDirectoryView_mainContent' }, [
+          t.if(
+            (vm) => vm.roomFetchError,
+            (t, vm) => {
+              return t.section({ className: 'RoomDirectoryView_roomListError' }, [
+                t.h3('Unable to fetch rooms from room directory'),
+                t.p({}, [
+                  `This may be a temporary problem with the homeserver where the room directory lives (${vm.searchParameters.homeserver}) or the homeserver that the archive is pulling from (${vm.homeserverName}). You can try adjusting your search term or picking a different homeserver to look at. If this problem persists, please open a `,
+                  t.a(
+                    { href: 'https://github.com/matrix-org/matrix-public-archive/issues/new' },
+                    'bug report'
+                  ),
+                  ` with all of these details copy-pasted into the issue.`,
+                ]),
+                t.p({}, `The exact error we ran into was:`),
+                t.pre({}, vm.roomFetchError.stack),
+                t.p({}, `The  error occured with these search paramers:`),
+                t.pre({}, JSON.stringify(vm.searchParameters, null, 2)),
+                t.details({}, [
+                  t.summary({}, 'Why are we showing so many details?'),
+                  t.p({}, [
+                    `We're showing as much detail as we know so you're not frustrated by a generic message with no feedback on how to move forward. This also makes it easier for you to write a `,
+                    t.a(
+                      { href: 'https://github.com/matrix-org/matrix-public-archive/issues/new' },
+                      'bug report'
+                    ),
+                    ` with all the details necessary for us to triage it.`,
+                  ]),
+                  t.p({}, t.strong(`Isn't this a security risk?`)),
+                  t.p({}, [
+                    `Not really. Usually, people are worried about returning details because it makes it easier for people to know how to prod and poke and get better feedback about what's going wrong to craft exploits. But the `,
+                    t.a(
+                      { href: 'https://github.com/matrix-org/matrix-public-archive' },
+                      'Matrix Public Archive'
+                    ),
+                    ` is open source so you can run your own instance against the same homeservers that we are to find problems.`,
+                  ]),
+                  t.p({}, [
+                    `If you find any security vulnerabilities, please `,
+                    t.a(
+                      { href: 'https://matrix.org/security-disclosure-policy/' },
+                      'responsibly disclose'
+                    ),
+                    ` them to us.`,
+                  ]),
+                  t.p({}, [
+                    `If you have ideas on how we can present these errors better, please `,
+                    t.a(
+                      { href: 'https://github.com/matrix-org/matrix-public-archive/issues' },
+                      'create an issue'
+                    ),
+                    `.`,
+                  ]),
+                ]),
+              ]);
+            }
+          ),
           t.view(roomList),
           t.div({ className: 'RoomDirectoryView_paginationButtonCombo' }, [
             t.a(

--- a/shared/views/RoomDirectoryView.js
+++ b/shared/views/RoomDirectoryView.js
@@ -172,7 +172,7 @@ class RoomDirectoryView extends TemplateView {
             (vm) => vm.roomFetchError,
             (t, vm) => {
               return t.section({ className: 'RoomDirectoryView_roomListError' }, [
-                t.h3('Unable to fetch rooms from room directory'),
+                t.h3('❗ Unable to fetch rooms from room directory'),
                 t.p({}, [
                   `This may be a temporary problem with the homeserver where the room directory lives (${vm.searchParameters.homeserver}) or the homeserver that the archive is pulling from (${vm.homeserverName}). You can try adjusting your search term or select a different homeserver to look at. If this problem persists, please open a `,
                   t.a(
@@ -181,6 +181,15 @@ class RoomDirectoryView extends TemplateView {
                   ),
                   ` with all of this whole section copy-pasted into the issue.`,
                 ]),
+                t.button(
+                  {
+                    className: 'PrimaryActionButton',
+                    onClick: () => {
+                      window.location.reload();
+                    },
+                  },
+                  'Refresh page'
+                ),
                 t.p({}, `The exact error we ran into was:`),
                 t.pre(
                   { className: 'RoomDirectoryView_codeBlock' },
@@ -219,7 +228,7 @@ class RoomDirectoryView extends TemplateView {
                     ` them to us.`,
                   ]),
                   t.p({}, [
-                    `If you have ideas on how we can present these errors better, please `,
+                    `If you have ideas on how we can better present these errors, please `,
                     t.a(
                       { href: 'https://github.com/matrix-org/matrix-public-archive/issues' },
                       'create an issue'

--- a/shared/views/RoomDirectoryView.js
+++ b/shared/views/RoomDirectoryView.js
@@ -174,17 +174,23 @@ class RoomDirectoryView extends TemplateView {
               return t.section({ className: 'RoomDirectoryView_roomListError' }, [
                 t.h3('Unable to fetch rooms from room directory'),
                 t.p({}, [
-                  `This may be a temporary problem with the homeserver where the room directory lives (${vm.searchParameters.homeserver}) or the homeserver that the archive is pulling from (${vm.homeserverName}). You can try adjusting your search term or picking a different homeserver to look at. If this problem persists, please open a `,
+                  `This may be a temporary problem with the homeserver where the room directory lives (${vm.searchParameters.homeserver}) or the homeserver that the archive is pulling from (${vm.homeserverName}). You can try adjusting your search term or select a different homeserver to look at. If this problem persists, please open a `,
                   t.a(
                     { href: 'https://github.com/matrix-org/matrix-public-archive/issues/new' },
                     'bug report'
                   ),
-                  ` with all of these details copy-pasted into the issue.`,
+                  ` with all of this whole section copy-pasted into the issue.`,
                 ]),
                 t.p({}, `The exact error we ran into was:`),
-                t.pre({}, vm.roomFetchError.stack),
+                t.pre(
+                  { className: 'RoomDirectoryView_codeBlock' },
+                  t.code({}, vm.roomFetchError.stack)
+                ),
                 t.p({}, `The  error occured with these search paramers:`),
-                t.pre({}, JSON.stringify(vm.searchParameters, null, 2)),
+                t.pre(
+                  { className: 'RoomDirectoryView_codeBlock' },
+                  t.code({}, JSON.stringify(vm.searchParameters, null, 2))
+                ),
                 t.details({}, [
                   t.summary({}, 'Why are we showing so many details?'),
                   t.p({}, [
@@ -202,7 +208,7 @@ class RoomDirectoryView extends TemplateView {
                       { href: 'https://github.com/matrix-org/matrix-public-archive' },
                       'Matrix Public Archive'
                     ),
-                    ` is open source so you can run your own instance against the same homeservers that we are to find problems.`,
+                    ` is already open source so the details of the app are already public and you can run your own instance against the same homeservers that we are to find problems.`,
                   ]),
                   t.p({}, [
                     `If you find any security vulnerabilities, please `,


### PR DESCRIPTION
Load room directory and show error message when we're unable to fetch rooms

Follow-up to https://github.com/matrix-org/matrix-public-archive/pull/84 to address https://github.com/matrix-org/matrix-public-archive/issues/80

Also explains why we show the details of the error message.

Part of https://github.com/matrix-org/internal-config/issues/1342

Related to https://github.com/matrix-org/matrix-public-archive/issues/97


![](https://user-images.githubusercontent.com/558581/197105213-f0a04795-e589-4ad9-8c29-15d87856e572.png)



### Image transcription


<blockquote>

### ❗ Unable to fetch rooms from room directory

This may be a temporary problem with the homeserver where the room directory lives (foo.bar) or the homeserver that the archive is pulling from (my.synapse.server). You can try adjusting your search term or select a different homeserver to look at. If this problem persists, please open a [bug report](https://github.com/matrix-org/matrix-public-archive/issues/new) with all of this whole section copy-pasted into the issue.

[Refresh page]

The exact error we ran into was:

```
Error: HTTP Error Response: 502 Bad Gateway: {"errcode":"M_UNKNOWN","error":"Failed to fetch room list"}
    URL=http://192.168.1.182:8008/_matrix/client/v3/publicRooms?server=foo.bar
    at checkResponseStatus (C:\Users\MLM\Documents\GitHub\element\matrix-public-archive\server\lib\fetch-endpoint.js:21:11)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
    at async fetchEndpoint (C:\Users\MLM\Documents\GitHub\element\matrix-public-archive\server\lib\fetch-endpoint.js:38:3)
    at async fetchEndpointAsJson (C:\Users\MLM\Documents\GitHub\element\matrix-public-archive\server\lib\fetch-endpoint.js:63:15)
    at async fetchPublicRooms (C:\Users\MLM\Documents\GitHub\element\matrix-public-archive\server\lib\matrix-utils\fetch-public-rooms.js:26:26)
    at async C:\Users\MLM\Documents\GitHub\element\matrix-public-archive\server\tracing\trace-utilities.js:31:24
    at async C:\Users\MLM\Documents\GitHub\element\matrix-public-archive\server\routes\room-directory-routes.js:46:62
```

The error occured with these search paramers:

```
{
  "homeserver": "foo.bar",
  "searchTerm": "",
  "limit": 9
}
```

<details>
<summary>Why are we showing so many details?</summary>

We're showing as much detail as we know so you're not frustrated by a generic message with no feedback on how to move forward. This also makes it easier for you to write a [bug report](https://github.com/matrix-org/matrix-public-archive/issues/new) with all the details necessary for us to triage it.

**Isn't this a security risk?**

Not really. Usually, people are worried about returning details because it makes it easier for people to know how to prod and poke and get better feedback about what's going wrong to craft exploits. But the [Matrix Public Archive](https://github.com/matrix-org/matrix-public-archive) is already open source so the details of the app are already public and you can run your own instance against the same homeservers that we are to find problems.

If you find any security vulnerabilities, please [responsibly disclose](https://matrix.org/security-disclosure-policy/) them to us.

If you have ideas on how we can better present these errors, please [create an issue](https://github.com/matrix-org/matrix-public-archive/issues).
</details>

</blockquote>

