### PR TITLE
Update `linkedom` with latest `<select>` and `<option>` updates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "express": "^4.17.2",
         "hydrogen-view-sdk": "npm:@mlm/hydrogen-view-sdk@^0.20.0-scratch",
         "json5": "^2.2.1",
-        "linkedom": "^0.14.17",
+        "linkedom": "^0.14.18",
         "matrix-public-archive-shared": "file:./shared/",
         "nconf": "^0.11.3",
         "node-fetch": "^2.6.7",
@@ -4019,9 +4019,9 @@
       "license": "MIT"
     },
     "node_modules/linkedom": {
-      "version": "0.14.17",
-      "resolved": "https://registry.npmjs.org/linkedom/-/linkedom-0.14.17.tgz",
-      "integrity": "sha512-PD6GQKvZ4s6Ai4/WkpyHc8MhiZdCz4hWmMOWJk+MO3/kl1QvPUbo4nQWS9+VHO7lRBk1ucIa9ONS9qzCUcBAmQ==",
+      "version": "0.14.18",
+      "resolved": "https://registry.npmjs.org/linkedom/-/linkedom-0.14.18.tgz",
+      "integrity": "sha512-5eV85zCEME1WLPJJ5R+Un8PAQM9RZLt+tKyoZKB0xNHysV3M/0YLI5SP5MvwZrkFC5TE+YRZexxMptB6JS2uow==",
       "dependencies": {
         "css-select": "^5.1.0",
         "cssom": "^0.5.0",
@@ -8319,9 +8319,9 @@
       }
     },
     "linkedom": {
-      "version": "0.14.17",
-      "resolved": "https://registry.npmjs.org/linkedom/-/linkedom-0.14.17.tgz",
-      "integrity": "sha512-PD6GQKvZ4s6Ai4/WkpyHc8MhiZdCz4hWmMOWJk+MO3/kl1QvPUbo4nQWS9+VHO7lRBk1ucIa9ONS9qzCUcBAmQ==",
+      "version": "0.14.18",
+      "resolved": "https://registry.npmjs.org/linkedom/-/linkedom-0.14.18.tgz",
+      "integrity": "sha512-5eV85zCEME1WLPJJ5R+Un8PAQM9RZLt+tKyoZKB0xNHysV3M/0YLI5SP5MvwZrkFC5TE+YRZexxMptB6JS2uow==",
       "requires": {
         "css-select": "^5.1.0",
         "cssom": "^0.5.0",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "express": "^4.17.2",
     "hydrogen-view-sdk": "npm:@mlm/hydrogen-view-sdk@^0.20.0-scratch",
     "json5": "^2.2.1",
-    "linkedom": "^0.14.17",
+    "linkedom": "^0.14.18",
     "matrix-public-archive-shared": "file:./shared/",
     "nconf": "^0.11.3",
     "node-fetch": "^2.6.7",

--- a/test/e2e-tests.js
+++ b/test/e2e-tests.js
@@ -701,11 +701,11 @@ describe('matrix-public-archive', () => {
         const domWithSearch = parseHTML(roomDirectoryWithSearchPageHtml);
 
         // Make sure the `?homserver` is selected in the homeserver selector `<select>`
-        const selectedHomeserverOptionElement = domWithSearch.document.querySelector(
-          `[data-testid="homeserver-select"] option[selected]`
+        const homeserverSelectElement = domWithSearch.document.querySelector(
+          `[data-testid="homeserver-select"]`
         );
         assert.strictEqual(
-          selectedHomeserverOptionElement.getAttribute('value'),
+          homeserverSelectElement.value,
           HOMESERVER_URL_TO_PRETTY_NAME_MAP[testMatrixServerUrl2]
         );
 


### PR DESCRIPTION
Update `linkedom` with latest `<select>` and `<option>` updates

See https://github.com/WebReflection/linkedom/issues/170


### Dev notes


#### `TypeError: Cannot set property value of [object Object] which has only a getter`

Tracked by https://github.com/WebReflection/linkedom/issues/171

Currently, the `linkedom@0.14.18` update makes us run into `TypeError: Cannot set property value of [object Object] which has only a getter` because there is no `value` setter for `<select>` elements (only a `getter` defined).

The problem spot which causes the page to fail to server-side render now:

https://github.com/matrix-org/matrix-public-archive/blob/dcc2f5dd03d6fce32a96de1a7a0707e8690fa109/shared/views/RoomDirectoryView.js#L172


<details>
<summary>Full error</summary>

```
RethrownError: Failed to render Hydrogen to string. In order to reproduce, feed in these arguments into `renderHydrogenToString(...)`:
    renderHydrogenToString arguments: {"vmRenderScriptFilePath":"C:\\Users\\MLM\\Documents\\GitHub\\element\\matrix-public-archive\\shared\\room-directory-vm-render-script.js","vmRenderContext":{"rooms":[],"roomFetchError":{"message":"HTTP Error Response: 502 Bad Gateway: {\"errcode\":\"M_UNKNOWN\",\"error\":\"Failed to fetch room list\"}\n    URL=http://192.168.1.182:8008/_matrix/client/v3/publicRooms?server=foo.bar","stack":"Error: HTTP Error Response: 502 Bad Gateway: {\"errcode\":\"M_UNKNOWN\",\"error\":\"Failed to fetch room list\"}\n    URL=http://192.168.1.182:8008/_matrix/client/v3/publicRooms?server=foo.bar\n    at checkResponseStatus (C:\\Users\\MLM\\Documents\\GitHub\\element\\matrix-public-archive\\server\\lib\\fetch-endpoint.js:21:11)\n    at processTicksAndRejections (node:internal/process/task_queues:96:5)\n    at async fetchEndpoint (C:\\Users\\MLM\\Documents\\GitHub\\element\\matrix-public-archive\\server\\lib\\fetch-endpoint.js:38:3)\n    at async fetchEndpointAsJson (C:\\Users\\MLM\\Documents\\GitHub\\element\\matrix-public-archive\\server\\lib\\fetch-endpoint.js:63:15)\n    at async fetchPublicRooms (C:\\Users\\MLM\\Documents\\GitHub\\element\\matrix-public-archive\\server\\lib\\matrix-utils\\fetch-public-rooms.js:26:26)\n    at async C:\\Users\\MLM\\Documents\\GitHub\\element\\matrix-public-archive\\server\\tracing\\trace-utilities.js:31:24\n    at async C:\\Users\\MLM\\Documents\\GitHub\\element\\matrix-public-archive\\server\\routes\\room-directory-routes.js:46:62"},"pageSearchParameters":{"homeserver":"foo.bar","searchTerm":"","limit":9},"config":{"basePath":"http://192.168.1.151:3050","matrixServerUrl":"http://192.168.1.182:8008/","matrixServerName":"my.synapse.server"}},"pageOptions":{"title":"Matrix Public Archive","styles":["http://192.168.1.151:3050/hydrogen-styles.css","http://192.168.1.151:3050/css/styles.css","http://192.168.1.151:3050/css/room-directory.css"],"scripts":["http://192.168.1.151:3050/js/entry-client-room-directory.es.js"],"cspNonce":"2047844ad46267c36e19f325324f11e1"}}
    at renderHydrogenToString (C:\Users\MLM\Documents\GitHub\element\matrix-public-archive\server\hydrogen-render\render-hydrogen-to-string.js:52:11)
    --- Original Error ---
    RethrownError: Child process exited with code 1 (somehow we saw 2 errors but we really always expect 1 error)
    0. TypeError: Cannot set property value of [object Object] which has only a getter
        at C:\Users\MLM\Documents\GitHub\element\matrix-public-archive\shared\views\RoomDirectoryView.js:172:39
        at TemplateBuilder.mapSideEffect (C:\Users\MLM\Documents\GitHub\element\matrix-public-archive\node_modules\hydrogen-view-sdk\lib-build\hydrogen.cjs.js:4081:5)
        at RoomDirectoryView.render (C:\Users\MLM\Documents\GitHub\element\matrix-public-archive\shared\views\RoomDirectoryView.js:169:7)
        at RoomDirectoryView.mount (C:\Users\MLM\Documents\GitHub\element\matrix-public-archive\node_modules\hydrogen-view-sdk\lib-build\hydrogen.cjs.js:3842:25)
        at mountHydrogen (room-directory-vm-render-script.js:90:35)
        at room-directory-vm-render-script.js:97:1
        at Script.runInContext (node:vm:139:12)
        at _renderHydrogenToStringUnsafe (C:\Users\MLM\Documents\GitHub\element\matrix-public-archive\server\hydrogen-render\render-hydrogen-to-string-unsafe.js:96:41)
        at async process.<anonymous> (C:\Users\MLM\Documents\GitHub\element\matrix-public-archive\server\child-process-runner\child-fork-script.js:72:20)
    1. RethrownError: uncaughtException in child process
        at process.<anonymous> (C:\Users\MLM\Documents\GitHub\element\matrix-public-archive\server\child-process-runner\child-fork-script.js:49:24)
        --- Original Error ---
        TypeError: this.dialogNode.close is not a function
            at ModalView.closeModal (C:\Users\MLM\Documents\GitHub\element\matrix-public-archive\shared\views\ModalView.js:115:21)
            at Timeout._onTimeout (C:\Users\MLM\Documents\GitHub\element\matrix-public-archive\shared\views\ModalView.js:87:18)
            at listOnTimeout (node:internal/timers:559:17)
            at processTimers (node:internal/timers:502:7)
        at assembleErrorAfterChildExitsWithErrors (C:\Users\MLM\Documents\GitHub\element\matrix-public-archive\server\child-process-runner\run-in-child-process.js:56:29)
        --- Original Error ---
        Multiple child errors listed above ^
```

</details>


```js
'use strict';

const {DOMParser, parseHTML} = require('linkedom');

parseHTML(`<select><option value="foo" selected="selected">foo</option></select>`).document.querySelector('select').value = 'bar';
```

