### PR TITLE
Fix pagination links not accounting for homeserver selection

### DIFF
--- a/shared/viewmodels/RoomDirectoryViewModel.js
+++ b/shared/viewmodels/RoomDirectoryViewModel.js
@@ -213,6 +213,7 @@ class RoomDirectoryViewModel extends ViewModel {
   get nextPageUrl() {
     if (this._nextPaginationToken) {
       return this._matrixPublicArchiveURLCreator.roomDirectoryUrl({
+        homeserver: this.homeserverSelection,
         searchTerm: this.searchTerm,
         paginationToken: this._nextPaginationToken,
       });
@@ -224,6 +225,7 @@ class RoomDirectoryViewModel extends ViewModel {
   get prevPageUrl() {
     if (this._prevPaginationToken) {
       return this._matrixPublicArchiveURLCreator.roomDirectoryUrl({
+        homeserver: this.homeserverSelection,
         searchTerm: this.searchTerm,
         paginationToken: this._prevPaginationToken,
       });


### PR DESCRIPTION
Fix pagination links not accounting for homeserver selection

Fix https://github.com/matrix-org/matrix-public-archive/issues/93

![](https://user-images.githubusercontent.com/558581/197286373-106ed446-4645-4eaf-acc1-b23322c14cbf.png)


Previously caused the `?homeserver` query parameter to be lost when paginating