### PR TITLE
Link rooms with `?via` query parameter from room directory landing page

### DIFF
--- a/shared/viewmodels/RoomDirectoryViewModel.js
+++ b/shared/viewmodels/RoomDirectoryViewModel.js
@@ -34,20 +34,6 @@ class RoomDirectoryViewModel extends ViewModel {
     this._homeserverUrl = homeserverUrl;
     this._homeserverName = homeserverName;
     this._matrixPublicArchiveURLCreator = matrixPublicArchiveURLCreator;
-    this._rooms = new ObservableArray(
-      rooms.map((room) => {
-        return {
-          roomId: room.room_id,
-          canonicalAlias: room.canonical_alias,
-          name: room.name,
-          mxcAvatarUrl: room.avatar_url,
-          homeserverUrlToPullMediaFrom: homeserverUrl,
-          numJoinedMembers: room.num_joined_members,
-          topic: room.topic,
-          archiveRoomUrl: matrixPublicArchiveURLCreator.archiveUrlForRoom(room.room_id),
-        };
-      })
-    );
 
     this._pageSearchParameters = pageSearchParameters;
     // Default to what the page started with
@@ -75,6 +61,23 @@ class RoomDirectoryViewModel extends ViewModel {
           const path = this.navigation.pathFrom([]);
           this.navigation.applyPath(path);
         },
+      })
+    );
+
+    this._rooms = new ObservableArray(
+      rooms.map((room) => {
+        return {
+          roomId: room.room_id,
+          canonicalAlias: room.canonical_alias,
+          name: room.name,
+          mxcAvatarUrl: room.avatar_url,
+          homeserverUrlToPullMediaFrom: homeserverUrl,
+          numJoinedMembers: room.num_joined_members,
+          topic: room.topic,
+          archiveRoomUrl: matrixPublicArchiveURLCreator.archiveUrlForRoom(room.room_id, {
+            viaServers: [this.pageSearchParameters.homeserver],
+          }),
+        };
       })
     );
 


### PR DESCRIPTION
Link rooms with `?via` query parameter from room directory landing page

Fix https://github.com/matrix-org/matrix-public-archive/issues/91

So we're always able to join the room from our origin homeserver to the remote room we don't know about yet.


![](https://user-images.githubusercontent.com/558581/197288521-fff687a3-877b-466e-9253-a949c8fd57f6.png)


