### PR TITLE
Fix form `<select>` value not being up to date by the time we auto-submit the form on selection

### DIFF
--- a/shared/views/RoomDirectoryView.js
+++ b/shared/views/RoomDirectoryView.js
@@ -183,8 +183,16 @@ class RoomDirectoryView extends TemplateView {
           // modal close callback but this races with it and sometimes we beat it.
           const path = vm.navigation.pathFrom([]);
           vm.navigation.applyPath(path);
-          // Submit the page with the new homeserver selection to get results.
-          headerForm.submit();
+
+          // Set the `<select>` value before we submit to ensure we have the most up to
+          // date information. Normally this would be updated by having Hydrogen do its
+          // render cycle and have the `<option selected>` be swapped around.
+          homeserverSelectElement.value = homeserverSelection;
+
+          setTimeout(() => {
+            // Submit the page with the new homeserver selection to get results.
+            headerForm.submit();
+          }, 0);
         }
       }
     );


### PR DESCRIPTION
Fix form `<select>` value not being up to date by the time we auto-submit the form on selection

Follow-up to https://github.com/matrix-org/matrix-public-archive/pull/102#discussion_r1002190782


Before | After (`foo.bar` in URL after we just added it)
--- | ---
![](https://user-images.githubusercontent.com/558581/197290845-3eaf3c2e-6091-432a-98d4-32bfdfe77e95.gif) | ![](https://user-images.githubusercontent.com/558581/197290854-4d6a1823-bb7e-4f1f-a93a-a7ea171eec86.gif)
