### PR TITLE
Add support for room aliases

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2857,8 +2857,9 @@
     },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=10"
       },
@@ -7586,6 +7587,8 @@
     },
     "escape-string-regexp": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
       "dev": true
     },
     "eslint": {

--- a/server/lib/matrix-utils/fetch-events-from-timestamp-backwards.js
+++ b/server/lib/matrix-utils/fetch-events-from-timestamp-backwards.js
@@ -76,7 +76,9 @@ async function fetchEventsFromTimestampBackwards({ accessToken, roomId, ts, limi
   // event mark.
   const contextEndpoint = urlJoin(
     matrixServerUrl,
-    `_matrix/client/r0/rooms/${roomId}/context/${eventIdForTimestamp}?limit=0&filter={"lazy_load_members":true}`
+    `_matrix/client/r0/rooms/${encodeURIComponent(roomId)}/context/${encodeURIComponent(
+      eventIdForTimestamp
+    )}?limit=0&filter={"lazy_load_members":true}`
   );
   const contextResData = await fetchEndpointAsJson(contextEndpoint, {
     accessToken,
@@ -86,7 +88,9 @@ async function fetchEventsFromTimestampBackwards({ accessToken, roomId, ts, limi
   // the messages included in the response
   const messagesEndpoint = urlJoin(
     matrixServerUrl,
-    `_matrix/client/r0/rooms/${roomId}/messages?dir=b&from=${contextResData.end}&limit=${limit}&filter={"lazy_load_members":true}`
+    `_matrix/client/r0/rooms/${encodeURIComponent(roomId)}/messages?dir=b&from=${encodeURIComponent(
+      contextResData.end
+    )}&limit=${limit}&filter={"lazy_load_members":true}`
   );
   const messageResData = await fetchEndpointAsJson(messagesEndpoint, {
     accessToken,

--- a/server/lib/matrix-utils/fetch-room-data.js
+++ b/server/lib/matrix-utils/fetch-room-data.js
@@ -16,28 +16,36 @@ async function fetchRoomData(accessToken, roomId) {
 
   const stateNameEndpoint = urlJoin(
     matrixServerUrl,
-    `_matrix/client/r0/rooms/${roomId}/state/m.room.name`
+    `_matrix/client/r0/rooms/${encodeURIComponent(roomId)}/state/m.room.name`
+  );
+  const canoncialAliasEndpoint = urlJoin(
+    matrixServerUrl,
+    `_matrix/client/r0/rooms/${encodeURIComponent(roomId)}/state/m.room.canonical_alias`
   );
   const stateAvatarEndpoint = urlJoin(
     matrixServerUrl,
-    `_matrix/client/r0/rooms/${roomId}/state/m.room.avatar`
+    `_matrix/client/r0/rooms/${encodeURIComponent(roomId)}/state/m.room.avatar`
   );
   const stateHistoryVisibilityEndpoint = urlJoin(
     matrixServerUrl,
-    `_matrix/client/r0/rooms/${roomId}/state/m.room.history_visibility`
+    `_matrix/client/r0/rooms/${encodeURIComponent(roomId)}/state/m.room.history_visibility`
   );
   const stateJoinRulesEndpoint = urlJoin(
     matrixServerUrl,
-    `_matrix/client/r0/rooms/${roomId}/state/m.room.join_rules`
+    `_matrix/client/r0/rooms/${encodeURIComponent(roomId)}/state/m.room.join_rules`
   );
 
   const [
     stateNameResDataOutcome,
+    stateCanonicalAliasResDataOutcome,
     stateAvatarResDataOutcome,
     stateHistoryVisibilityResDataOutcome,
     stateJoinRulesResDataOutcome,
   ] = await Promise.allSettled([
     fetchEndpointAsJson(stateNameEndpoint, {
+      accessToken,
+    }),
+    fetchEndpointAsJson(canoncialAliasEndpoint, {
       accessToken,
     }),
     fetchEndpointAsJson(stateAvatarEndpoint, {
@@ -54,6 +62,11 @@ async function fetchRoomData(accessToken, roomId) {
   let name;
   if (stateNameResDataOutcome.reason === undefined) {
     name = stateNameResDataOutcome.value.name;
+  }
+
+  let canonicalAlias;
+  if (stateCanonicalAliasResDataOutcome.reason === undefined) {
+    canonicalAlias = stateCanonicalAliasResDataOutcome.value.alias;
   }
 
   let avatarUrl;
@@ -74,6 +87,7 @@ async function fetchRoomData(accessToken, roomId) {
   return {
     id: roomId,
     name,
+    canonicalAlias,
     avatarUrl,
     historyVisibility,
     joinRule,

--- a/server/lib/matrix-utils/timestamp-to-event.js
+++ b/server/lib/matrix-utils/timestamp-to-event.js
@@ -18,7 +18,9 @@ async function timestampToEvent({ accessToken, roomId, ts, direction }) {
 
   const timestampToEventEndpoint = urlJoin(
     matrixServerUrl,
-    `_matrix/client/unstable/org.matrix.msc3030/rooms/${roomId}/timestamp_to_event?ts=${ts}&dir=${direction}`
+    `_matrix/client/unstable/org.matrix.msc3030/rooms/${encodeURIComponent(
+      roomId
+    )}/timestamp_to_event?ts=${encodeURIComponent(ts)}&dir=${encodeURIComponent(direction)}`
   );
   const timestampToEventResData = await fetchEndpointAsJson(timestampToEventEndpoint, {
     accessToken,

--- a/server/routes/install-routes.js
+++ b/server/routes/install-routes.js
@@ -58,7 +58,10 @@ function installRoutes(app) {
 
   app.use('/', require('./room-directory-routes'));
 
-  app.use('/:roomIdOrAlias', require('./room-routes'));
+  // For room aliases
+  app.use('/r/:roomIdOrAlias', require('./room-routes'));
+  // For room ID's
+  app.use('/roomid/:roomIdOrAlias', require('./room-routes'));
 }
 
 module.exports = installRoutes;

--- a/server/routes/install-routes.js
+++ b/server/routes/install-routes.js
@@ -8,6 +8,7 @@ const { handleTracingMiddleware } = require('../tracing/tracing-middleware');
 const getVersionTags = require('../lib/get-version-tags');
 const preventClickjackingMiddleware = require('./prevent-clickjacking-middleware');
 const contentSecurityPolicyMiddleware = require('./content-security-policy-middleware');
+const redirectToCorrectArchiveUrlIfBadSigil = require('./redirect-to-correct-archive-url-if-bad-sigil-middleware');
 
 function installRoutes(app) {
   app.use(handleTracingMiddleware);
@@ -58,10 +59,12 @@ function installRoutes(app) {
 
   app.use('/', require('./room-directory-routes'));
 
-  // For room aliases
-  app.use('/r/:roomIdOrAlias', require('./room-routes'));
-  // For room ID's
-  app.use('/roomid/:roomIdOrAlias', require('./room-routes'));
+  // For room aliases (/r) or room ID's (/roomid)
+  app.use('/:entityDescriptor(r|roomid)/:roomIdOrAliasDirty', require('./room-routes'));
+
+  // Correct any honest mistakes: If someone accidentally put the sigil in the URL, then
+  // redirect them to the correct URL without the sigil to the correct path above.
+  app.use('/:roomIdOrAliasDirty', redirectToCorrectArchiveUrlIfBadSigil);
 }
 
 module.exports = installRoutes;

--- a/server/routes/redirect-to-correct-archive-url-if-bad-sigil-middleware.js
+++ b/server/routes/redirect-to-correct-archive-url-if-bad-sigil-middleware.js
@@ -45,7 +45,7 @@ function redirectToCorrectArchiveUrlIfBadSigilMiddleware(req, res, next) {
       `(/(?:r|roomid))?/${escapeStringRegexp(roomIdOrAliasDirty)}(/?.*)`
     );
     urlObj.pathname = urlObj.pathname.replace(dirtyPathRegex, (_match, _beforePath, afterPath) => {
-      return `/${entityDescriptor}/${roomIdOrAliasWithoutSigil}${afterPath}`;
+      return `/${entityDescriptor}/${encodeURIComponent(roomIdOrAliasWithoutSigil)}${afterPath}`;
     });
 
     res.redirect(301, urlObj.toString());

--- a/server/routes/redirect-to-correct-archive-url-if-bad-sigil-middleware.js
+++ b/server/routes/redirect-to-correct-archive-url-if-bad-sigil-middleware.js
@@ -1,0 +1,58 @@
+'use strict';
+
+const assert = require('assert');
+const escapeStringRegexp = require('escape-string-regexp');
+
+const config = require('../lib/config');
+const basePath = config.get('basePath');
+assert(basePath);
+
+const VALID_SIGIL_TO_ENTITY_DESCRIPTOR_MAP = {
+  '#': 'r',
+  '!': 'roomid',
+};
+
+// Correct any honest mistakes: If someone accidentally put the sigil in the URL, then
+// redirect them to the correct URL without the sigil.
+//
+// Redirect examples:
+// - `/roomid/!xxx:my.synapse.server` -> `/roomid/xxx:my.synapse.server`
+// - `/roomid/!xxx:my.synapse.server/date/2022/09/20?via=my.synapse.server` -> `/roomid/xxx:my.synapse.server/date/2022/09/20?via=my.synapse.server`
+// - `/!xxx:my.synapse.server` -> `/roomid/xxx:my.synapse.server`
+function redirectToCorrectArchiveUrlIfBadSigilMiddleware(req, res, next) {
+  // This could be with or with our without the sigil. Although the correct thing here
+  // is to have no sigil. We will try to correct it for them in any case.
+  const roomIdOrAliasDirty = req.params.roomIdOrAliasDirty;
+  const roomIdOrAliasWithoutSigil = roomIdOrAliasDirty.replace(/^(#|!)/, '');
+
+  if (
+    roomIdOrAliasDirty.startsWith('!') ||
+    // It isn't possible to put the room alias `#` in the URI since everything after a
+    // `#` is only visible client-side but just put the logic here for clarity. We
+    // handle this redirect on the client.
+    roomIdOrAliasDirty.startsWith('#')
+  ) {
+    const sigil = roomIdOrAliasDirty[0];
+    const entityDescriptor = VALID_SIGIL_TO_ENTITY_DESCRIPTOR_MAP[sigil];
+    if (!entityDescriptor) {
+      throw new Error(
+        `Unknown sigil=${sigil} has no entityDescriptor. This is an error with the Matrix Public Archive itself (please open an issue).`
+      );
+    }
+
+    const urlObj = new URL(req.originalUrl, basePath);
+    const dirtyPathRegex = new RegExp(
+      `(/(?:r|roomid))?/${escapeStringRegexp(roomIdOrAliasDirty)}(/?.*)`
+    );
+    urlObj.pathname = urlObj.pathname.replace(dirtyPathRegex, (_match, _beforePath, afterPath) => {
+      return `/${entityDescriptor}/${roomIdOrAliasWithoutSigil}${afterPath}`;
+    });
+
+    res.redirect(301, urlObj.toString());
+    return;
+  }
+
+  next();
+}
+
+module.exports = redirectToCorrectArchiveUrlIfBadSigilMiddleware;

--- a/server/routes/redirect-to-correct-archive-url-if-bad-sigil-middleware.js
+++ b/server/routes/redirect-to-correct-archive-url-if-bad-sigil-middleware.js
@@ -61,6 +61,7 @@ function redirectToCorrectArchiveUrlIfBadSigilMiddleware(req, res, next) {
       return `/${entityDescriptor}/${roomIdOrAliasWithoutSigil}${afterPath}`;
     });
 
+    // 301 permanent redirect any mistakes to the correct place
     res.redirect(301, urlObj.toString());
     return;
   }

--- a/server/routes/room-routes.js
+++ b/server/routes/room-routes.js
@@ -130,7 +130,10 @@ router.get(
     // Redirect to a day with messages
     res.redirect(
       matrixPublicArchiveURLCreator.archiveUrlForDate(roomIdOrAlias, new Date(originServerTs), {
-        viaServers: req.query.via,
+        // We can avoid passing along the `via` query parameter because we already
+        // joined the room above (see `ensureRoomJoined`).
+        //
+        //viaServers: req.query.via,
       })
     );
   })

--- a/server/routes/room-routes.js
+++ b/server/routes/room-routes.js
@@ -114,12 +114,12 @@ router.get(
 
     // We have to wait for the room join to happen first before we can fetch
     // any of the additional room info or messages.
-    await ensureRoomJoined(matrixAccessToken, roomIdOrAlias, req.query.via);
+    const roomId = await ensureRoomJoined(matrixAccessToken, roomIdOrAlias, req.query.via);
 
     // Find the closest day to today with messages
     const { originServerTs } = await timestampToEvent({
       accessToken: matrixAccessToken,
-      roomId: roomIdOrAlias,
+      roomId,
       ts: dateBeforeJoin,
       direction: 'b',
     });
@@ -221,18 +221,18 @@ router.get(
 
     // We have to wait for the room join to happen first before we can fetch
     // any of the additional room info or messages.
-    await ensureRoomJoined(matrixAccessToken, roomIdOrAlias, req.query.via);
+    const roomId = await ensureRoomJoined(matrixAccessToken, roomIdOrAlias, req.query.via);
 
     // Do these in parallel to avoid the extra time in sequential round-trips
     // (we want to display the archive page faster)
     const [roomData, { events, stateEventMap }] = await Promise.all([
-      fetchRoomData(matrixAccessToken, roomIdOrAlias),
+      fetchRoomData(matrixAccessToken, roomId),
       // We over-fetch messages outside of the range of the given day so that we
       // can display messages from surrounding days (currently only from days
       // before) so that the quiet rooms don't feel as desolate and broken.
       fetchEventsFromTimestampBackwards({
         accessToken: matrixAccessToken,
-        roomId: roomIdOrAlias,
+        roomId,
         ts: toTimestamp,
         // We fetch one more than the `archiveMessageLimit` so that we can see
         // there are too many messages from the given day. If we have over the

--- a/server/routes/room-routes.js
+++ b/server/routes/room-routes.js
@@ -275,7 +275,7 @@ router.get(
       // need to look at the oldest event in the chronological list.
       //
       // XXX: In the future when we also fetch events from days after, we will
-      // need next day check.
+      // need to change this next day check.
       events[0].origin_server_ts >= fromTimestamp
     ) {
       res.send('TODO: Redirect user to smaller hour range');

--- a/shared/hydrogen-vm-render-script.js
+++ b/shared/hydrogen-vm-render-script.js
@@ -326,7 +326,7 @@ async function mountHydrogen() {
         },
         tag.a(
           {
-            href: matrixPublicArchiveURLCreator.permalinkForRoomId(roomData.id),
+            href: matrixPublicArchiveURLCreator.permalinkForRoom(roomData.id),
             rel: 'noopener',
             target: '_blank',
           },

--- a/shared/hydrogen-vm-render-script.js
+++ b/shared/hydrogen-vm-render-script.js
@@ -191,7 +191,8 @@ async function mountHydrogen() {
     // -1 so we're not at 00:00:00 of the next day
     origin_server_ts: toTimestamp - 1,
     content: {
-      daySummaryKind: daySummaryKind,
+      canonicalAlias: roomData.canonicalAlias,
+      daySummaryKind,
       // The timestamp from the URL that was originally visited
       dayTimestamp: fromTimestamp,
       // The end of the range to use as a jumping off point to the next activity

--- a/shared/hydrogen-vm-render-script.js
+++ b/shared/hydrogen-vm-render-script.js
@@ -143,6 +143,7 @@ async function mountHydrogen() {
   const room = {
     name: roomData.name,
     id: roomData.id,
+    canonicalAlias: roomData.canonicalAlias,
     avatarUrl: roomData.avatarUrl,
     avatarColorId: roomData.id,
     mediaRepository: mediaRepository,

--- a/shared/lib/url-creator.js
+++ b/shared/lib/url-creator.js
@@ -18,6 +18,7 @@ class URLCreator {
   }
 
   permalinkForRoom(roomIdOrAlias) {
+    // We don't `encodeURIComponent(...)` because the URL looks nicer without encoded things
     return `https://matrix.to/#/${roomIdOrAlias}`;
   }
 
@@ -38,6 +39,7 @@ class URLCreator {
 
   _getArchiveUrlPathForRoomIdOrAlias(roomIdOrAlias) {
     let urlPath;
+    // We don't `encodeURIComponent(...)` because the URL looks nicer without encoded things
     if (roomIdOrAlias.startsWith('#')) {
       urlPath = `/r/${roomIdOrAlias.replace(/^#/, '')}`;
     } else if (roomIdOrAlias.startsWith('!')) {

--- a/shared/lib/url-creator.js
+++ b/shared/lib/url-creator.js
@@ -17,8 +17,8 @@ class URLCreator {
     this._basePath = basePath;
   }
 
-  permalinkForRoomId(roomId) {
-    return `https://matrix.to/#/${roomId}`;
+  permalinkForRoom(roomIdOrAlias) {
+    return `https://matrix.to/#/${roomIdOrAlias}`;
   }
 
   roomDirectoryUrl({ searchTerm, homeserver, paginationToken } = {}) {
@@ -36,12 +36,19 @@ class URLCreator {
     return `${this._basePath}${qsToUrlPiece(qs)}`;
   }
 
-  archiveUrlForRoom(roomId, { viaServers = [] } = {}) {
-    assert(roomId);
+  archiveUrlForRoom(roomIdOrAlias, { viaServers = [] } = {}) {
+    assert(roomIdOrAlias);
     let qs = new URLSearchParams();
     [].concat(viaServers).forEach((viaServer) => {
       qs.append('via', viaServer);
     });
+
+    let asdf;
+    if (roomIdOrAlias.startsWith('#')) {
+      asdf = `/r/${roomIdOrAlias}`;
+    } else if (roomIdOrAlias.startsWith('!')) {
+      asdf = `/roomid/${roomIdOrAlias}`;
+    }
 
     return `${urlJoin(this._basePath, `${roomId}`)}${qsToUrlPiece(qs)}`;
   }

--- a/shared/lib/url-creator.js
+++ b/shared/lib/url-creator.js
@@ -36,6 +36,21 @@ class URLCreator {
     return `${this._basePath}${qsToUrlPiece(qs)}`;
   }
 
+  _getArchiveUrlPathForRoomIdOrAlias(roomIdOrAlias) {
+    let urlPath;
+    if (roomIdOrAlias.startsWith('#')) {
+      urlPath = `/r/${roomIdOrAlias.replace(/^#/, '')}`;
+    } else if (roomIdOrAlias.startsWith('!')) {
+      urlPath = `/roomid/${roomIdOrAlias.replace(/^!/, '')}`;
+    } else {
+      throw new Error(
+        'URLCreator._getArchiveUrlPathForRoomIdOrAlias(...): roomIdOrAlias should start with # (alias) or ! (room ID)'
+      );
+    }
+
+    return urlPath;
+  }
+
   archiveUrlForRoom(roomIdOrAlias, { viaServers = [] } = {}) {
     assert(roomIdOrAlias);
     let qs = new URLSearchParams();
@@ -43,18 +58,13 @@ class URLCreator {
       qs.append('via', viaServer);
     });
 
-    let asdf;
-    if (roomIdOrAlias.startsWith('#')) {
-      asdf = `/r/${roomIdOrAlias}`;
-    } else if (roomIdOrAlias.startsWith('!')) {
-      asdf = `/roomid/${roomIdOrAlias}`;
-    }
+    const urlPath = this._getArchiveUrlPathForRoomIdOrAlias(roomIdOrAlias);
 
-    return `${urlJoin(this._basePath, `${roomId}`)}${qsToUrlPiece(qs)}`;
+    return `${urlJoin(this._basePath, `${urlPath}`)}${qsToUrlPiece(qs)}`;
   }
 
-  archiveUrlForDate(roomId, date, { viaServers = [] } = {}) {
-    assert(roomId);
+  archiveUrlForDate(roomIdOrAlias, date, { viaServers = [] } = {}) {
+    assert(roomIdOrAlias);
     assert(date);
 
     let qs = new URLSearchParams();
@@ -62,15 +72,17 @@ class URLCreator {
       qs.append('via', viaServer);
     });
 
+    const urlPath = this._getArchiveUrlPathForRoomIdOrAlias(roomIdOrAlias);
+
     // Gives the date in YYYY/mm/dd format.
     // date.toISOString() -> 2022-02-16T23:20:04.709Z
     const urlDate = date.toISOString().split('T')[0].replaceAll('-', '/');
 
-    return `${urlJoin(this._basePath, `${roomId}/date/${urlDate}`)}${qsToUrlPiece(qs)}`;
+    return `${urlJoin(this._basePath, `${urlPath}/date/${urlDate}`)}${qsToUrlPiece(qs)}`;
   }
 
-  archiveJumpUrlForRoom(roomId, { ts, dir }) {
-    assert(roomId);
+  archiveJumpUrlForRoom(roomIdOrAlias, { ts, dir }) {
+    assert(roomIdOrAlias);
     assert(ts);
     assert(dir);
 
@@ -78,7 +90,9 @@ class URLCreator {
     qs.append('ts', ts);
     qs.append('dir', dir);
 
-    return `${urlJoin(this._basePath, `${roomId}/jump`)}${qsToUrlPiece(qs)}`;
+    const urlPath = this._getArchiveUrlPathForRoomIdOrAlias(roomIdOrAlias);
+
+    return `${urlJoin(this._basePath, `${urlPath}/jump`)}${qsToUrlPiece(qs)}`;
   }
 }
 

--- a/shared/viewmodels/ArchiveRoomViewModel.js
+++ b/shared/viewmodels/ArchiveRoomViewModel.js
@@ -170,7 +170,7 @@ class ArchiveRoomViewModel extends ViewModel {
     // Update the URL
     this.history.replaceUrlSilently(
       this._matrixPublicArchiveURLCreator.archiveUrlForDate(
-        this._room.id,
+        this._room.canonicalAlias || this._room.id,
         new Date(currentTopPositionEventEntry.timestamp)
       ) + window.location.hash
     );

--- a/shared/viewmodels/CalendarViewModel.js
+++ b/shared/viewmodels/CalendarViewModel.js
@@ -39,7 +39,10 @@ class CalendarViewModel extends ViewModel {
   }
 
   archiveUrlForDate(date) {
-    return this._matrixPublicArchiveURLCreator.archiveUrlForDate(this._room.id, date);
+    return this._matrixPublicArchiveURLCreator.archiveUrlForDate(
+      this._room.canonicalAlias || this._room.id,
+      date
+    );
   }
 
   prevMonth() {

--- a/shared/viewmodels/DeveloperOptionsContentViewModel.js
+++ b/shared/viewmodels/DeveloperOptionsContentViewModel.js
@@ -5,11 +5,12 @@ const { ViewModel } = require('hydrogen-view-sdk');
 const DEBUG_ACTIVE_DATE_INTERSECTION_OBSERVER_LOCAL_STORAGE_KEY =
   'debugActiveDateIntersectionObserver';
 
-class DeveloperOptionsViewModel extends ViewModel {
+class DeveloperOptionsContentViewModel extends ViewModel {
   constructor(options) {
     super(options);
-    const { debugActiveDateIntersectionObserver = false } = options;
+    const { room, debugActiveDateIntersectionObserver = false } = options;
 
+    this._room = room;
     this._debugActiveDateIntersectionObserver = debugActiveDateIntersectionObserver;
   }
 
@@ -36,6 +37,10 @@ class DeveloperOptionsViewModel extends ViewModel {
     );
     this.emitChange('debugActiveDateIntersectionObserver');
   }
+
+  get roomId() {
+    return this._room.id;
+  }
 }
 
-module.exports = DeveloperOptionsViewModel;
+module.exports = DeveloperOptionsContentViewModel;

--- a/shared/viewmodels/ModalViewModel.js
+++ b/shared/viewmodels/ModalViewModel.js
@@ -2,7 +2,7 @@
 
 const { ViewModel } = require('hydrogen-view-sdk');
 
-class DeveloperOptionsViewModel extends ViewModel {
+class ModalViewModel extends ViewModel {
   constructor(options) {
     super(options);
     const { title, contentViewModel, closeCallback, open = false } = options;
@@ -35,4 +35,4 @@ class DeveloperOptionsViewModel extends ViewModel {
   }
 }
 
-module.exports = DeveloperOptionsViewModel;
+module.exports = ModalViewModel;

--- a/shared/viewmodels/NotEnoughEventsFromDaySummaryTileViewModel.js
+++ b/shared/viewmodels/NotEnoughEventsFromDaySummaryTileViewModel.js
@@ -33,11 +33,13 @@ class NotEnoughEventsFromDaySummaryTileViewModel extends SimpleTile {
   }
 
   get jumpToNextActivityUrl() {
-    console.log('this._entry TODO', this._entry);
-    return this._matrixPublicArchiveURLCreator.archiveJumpUrlForRoom(this._entry.roomId, {
-      ts: this.rangeEndTimestamp,
-      dir: 'f',
-    });
+    return this._matrixPublicArchiveURLCreator.archiveJumpUrlForRoom(
+      this._entry?.content?.['canonicalAlias'] || this._entry.roomId,
+      {
+        ts: this.rangeEndTimestamp,
+        dir: 'f',
+      }
+    );
   }
 }
 

--- a/shared/viewmodels/NotEnoughEventsFromDaySummaryTileViewModel.js
+++ b/shared/viewmodels/NotEnoughEventsFromDaySummaryTileViewModel.js
@@ -33,6 +33,7 @@ class NotEnoughEventsFromDaySummaryTileViewModel extends SimpleTile {
   }
 
   get jumpToNextActivityUrl() {
+    console.log('this._entry TODO', this._entry);
     return this._matrixPublicArchiveURLCreator.archiveJumpUrlForRoom(this._entry.roomId, {
       ts: this.rangeEndTimestamp,
       dir: 'f',

--- a/shared/viewmodels/RoomDirectoryViewModel.js
+++ b/shared/viewmodels/RoomDirectoryViewModel.js
@@ -74,9 +74,13 @@ class RoomDirectoryViewModel extends ViewModel {
           homeserverUrlToPullMediaFrom: homeserverUrl,
           numJoinedMembers: room.num_joined_members,
           topic: room.topic,
-          archiveRoomUrl: matrixPublicArchiveURLCreator.archiveUrlForRoom(room.room_id, {
-            viaServers: [this.pageSearchParameters.homeserver],
-          }),
+          archiveRoomUrl: matrixPublicArchiveURLCreator.archiveUrlForRoom(
+            room.canonical_alias || room.room_id,
+            {
+              // Only include via servers when we have to fallback to the room ID
+              viaServers: room.canonical_alias ? undefined : [this.pageSearchParameters.homeserver],
+            }
+          ),
         };
       })
     );

--- a/shared/views/DeveloperOptionsContentView.js
+++ b/shared/views/DeveloperOptionsContentView.js
@@ -28,6 +28,7 @@ class DeveloperOptionsContentView extends TemplateView {
         ]),
       ]),
       t.section([t.h4('Backend timing'), 'todo: window.tracingSpansForRequest']),
+      t.section([t.h4('Room ID'), t.pre({}, t.code({}, vm.roomId))]),
     ]);
   }
 }

--- a/test/client-utils.js
+++ b/test/client-utils.js
@@ -138,7 +138,7 @@ async function joinRoom({ client, roomId, viaServers }) {
 
   const joinRoomUrl = urlJoin(
     client.homeserverUrl,
-    `/_matrix/client/v3/join/${roomId}?${qs.toString()}`
+    `/_matrix/client/v3/join/${encodeURIComponent(roomId)}?${qs.toString()}`
   );
   const joinRoomResponse = await fetchEndpointAsJson(joinRoomUrl, {
     method: 'POST',
@@ -174,12 +174,16 @@ async function sendEvent({ client, roomId, eventType, stateKey, content, timesta
   if (stateKey) {
     url = urlJoin(
       client.homeserverUrl,
-      `/_matrix/client/v3/rooms/${roomId}/state/${eventType}/${stateKey}?${qs.toString()}`
+      `/_matrix/client/v3/rooms/${encodeURIComponent(
+        roomId
+      )}/state/${eventType}/${stateKey}?${qs.toString()}`
     );
   } else {
     url = urlJoin(
       client.homeserverUrl,
-      `/_matrix/client/v3/rooms/${roomId}/send/${eventType}/${getTxnId()}?${qs.toString()}`
+      `/_matrix/client/v3/rooms/${encodeURIComponent(
+        roomId
+      )}/send/${eventType}/${getTxnId()}?${qs.toString()}`
     );
   }
 

--- a/test/client-utils.js
+++ b/test/client-utils.js
@@ -124,6 +124,23 @@ async function createTestRoom(client, overrideCreateOptions = {}) {
   return roomId;
 }
 
+async function getCanonicalAlias({ client, roomId }) {
+  const stateCanonicalAliasRes = await fetchEndpointAsJson(
+    urlJoin(
+      client.homeserverUrl,
+      `_matrix/client/r0/rooms/${encodeURIComponent(roomId)}/state/m.room.canonical_alias`
+    ),
+    {
+      accessToken: client.accessToken,
+    }
+  );
+
+  const canonicalAlias = stateCanonicalAliasRes.alias;
+  assert(canonicalAlias, `getCanonicalAlias() did not return canonicalAlias as expected`);
+
+  return canonicalAlias;
+}
+
 async function joinRoom({ client, roomId, viaServers }) {
   let qs = new URLSearchParams();
   if (viaServers) {
@@ -313,6 +330,7 @@ module.exports = {
   getTestClientForAs,
   getTestClientForHs,
   createTestRoom,
+  getCanonicalAlias,
   joinRoom,
   sendEvent,
   sendMessage,

--- a/test/e2e-tests.js
+++ b/test/e2e-tests.js
@@ -826,7 +826,9 @@ describe('matrix-public-archive', () => {
           // expected in the URL's.
           //
           // We could lookup the date of the latest event to use the `origin_server_ts`
-          // from ourselves which may be less faff than this big warning but 🤷
+          // from ourselves which may be less faff than this big warning but 🤷 - that's
+          // kinda like making sure `/timestamp_to_event` works by using
+          // `/timestamp_to_event`.
           const utcMidnightOfNowDay = Date.UTC(
             nowDate.getUTCFullYear(),
             nowDate.getUTCMonth(),


### PR DESCRIPTION
Add support for room aliases. Also does friendly redirects if you don't exactly use the right URL pattern. For example, if you paste the full room ID with the `!` like `/roomid/!foo:bar`, it will properly redirect you to `/roomid/foo:bar`. It also does this sort of thing for URL encoded room ID's and aliases.

Fix https://github.com/matrix-org/matrix-public-archive/issues/25

> [...] we can use a schemaless [Matrix URI (`matrix://`)](https://github.com/matrix-org/matrix-spec-proposals/pull/2312/files) which doesn't include the sigils so there is no URL encoding issue.
> 
> The URL's for the archive end up looking like:
> 
>  - Room alias: `/r/matrix:matrix.org/date/2022/06/28`
>  - Room ID: `/roomid/OGEhHVWSdvArJzumhm:matrix.org/date/2022/06/28`


## Todo

 - [x] Update links on room directory to reflect alias usage now
 - [ ] Add client-side redirects when someone just pastes a room alias on the end of the domain
 - [x] If someone visits via `/roomid/...`, we shouldn't switch them over to room alias or vice versa
 - [x] Add tests for visiting room by room ID or room alias
 - [x] Add tests for room ID honest mistake redirects:
    - [x] `/roomid/!HBehERstyQBxyJDLfR:my.synapse.server` -> `/roomid/HBehERstyQBxyJDLfR:my.synapse.server`
    - [x] `/roomid/!HBehERstyQBxyJDLfR:my.synapse.server/date/2022/09/20?via=my.synapse.server` -> `/roomid/HBehERstyQBxyJDLfR:my.synapse.server/date/2022/09/20?via=my.synapse.server`
    - [x] `/!HBehERstyQBxyJDLfR:my.synapse.server` -> `/roomid/HBehERstyQBxyJDLfR:my.synapse.server`
    - We can't test room alias honest mistakes because those redirects happen client-side
 - [x] Test with URI encoded values `%23test-room1%3Amy.synapse.server`, `!HBehERstyQBxyJDLfR%3Amy.synapse.server`
 
 
## Dev notes


```js
const nowDate = new Date();

// Warn if it's close to the end of the UTC day. This test could be a flakey
// and cause a failure if the room was created just before midnight (UTC) and
// this timestamp comes after midnight. The redirect would want to go to the
// day before when the latest event was created instead of the `nowDate` we
// expected in the URL's.
//
// We could lookup the date of the latest event to use the `origin_server_ts`
// from ourselves which may be less faff than this big warning but 🤷
const utcMidnightOfNowDay = Date.UTC(
  nowDate.getUTCFullYear(),
  nowDate.getUTCMonth(),
  nowDate.getUTCDate() + 1
);
if (utcMidnightOfNowDay - nowDate.getTime() < 30 * 1000 /* 30 seconds */) {
  // eslint-disable-next-line no-console
  console.warn(
    `Test is being run at the end of the UTC day. This could result in a flakey ` +
      `failure where the room was created before midnight (UTC) but the \`nowDate\` ` +
      `was after midnight meaning our expected URL's would be a day ahead. Since ` +
      `this is an e2e test we can't control the date/time exactly.`
  );
}
```