### PR TITLE
Fix URL being duplicated in query param

### DIFF
--- a/shared/lib/archive-history.js
+++ b/shared/lib/archive-history.js
@@ -28,20 +28,52 @@ class ArchiveHistory extends History {
     // downstream call of `urlRouter.attach()` which we do when bootstraping
     // everything.
     if (window.history) {
-      let replacingUrl = document?.location?.search + url;
-      // This is a way to make sure the hash gets cleared out
-      if (url === '') {
+      let replacingUrl;
+      // Hydrogen hash routing on the end of the URL
+      if (url.startsWith('#')) {
+        replacingUrl = url;
+      }
+      // Hydrogen hash routing: This is the sign that Hydrogen is navigating back to the
+      // root. Because of our custom archive logic, the `#` is removed before it gets
+      // here. But we just want to make sure the hash gets cleared out while maintaining
+      // our path and query parameters.
+      //
+      // Before: /foo?search=bar#/developer-options
+      // pushUrlSilently(url='')
+      // After: /foo?search=bar
+      else if (url === '') {
         replacingUrl = document?.location?.pathname + document?.location?.search;
+      }
+      // Otherwise, it's probably an absolute URL that we can totally replace the page
+      // URL with
+      else {
+        replacingUrl = url;
       }
       super.replaceUrlSilently(replacingUrl);
     }
   }
 
   pushUrlSilently(url) {
-    let replacingUrl = document?.location?.search + url;
-    // This is a way to make sure the hash gets cleared out
-    if (url === '') {
+    let replacingUrl;
+    // Hydrogen hash routing on the end of the URL
+    if (url.startsWith('#')) {
+      replacingUrl = url;
+    }
+    // Hydrogen hash routing: This is the sign that Hydrogen is navigating back to the
+    // root. Because of our custom archive logic, the `#` is removed before it gets
+    // here. But we just want to make sure the hash gets cleared out while maintaining
+    // our path and query parameters.
+    //
+    // Before: /foo?search=bar#/developer-options
+    // pushUrlSilently(url='')
+    // After: /foo?search=bar
+    else if (url === '') {
       replacingUrl = document?.location?.pathname + document?.location?.search;
+    }
+    // Otherwise, it's probably an absolute URL that we can totally replace the page
+    // URL with
+    else {
+      replacingUrl = url;
     }
     super.pushUrlSilently(replacingUrl);
   }


### PR DESCRIPTION
Fix URL being duplicated in query param

Fix https://github.com/matrix-org/matrix-public-archive/pull/104#discussion_r1004023030


### What was the problem?

We were previously seeing this behavior with the old code:

```
Before: http://localhost:3050/!xxx:server/date/2022/09/20?via=my.synapse.server
replaceUrlSilently(url='http://localhost:3050/!xxx:server/date/2022/09/20')`
After: http://localhost:3050/!xxx:server/date/2022/09/20?via=my.synapse.serverhttp://localhost:3050/!xxx:server/date/2022/07/29
```

Because `replacingUrl` was evaluating to `replacingUrl = '?via=my.synapse.serverhttp://192.168.1.151:3050/!HBehERstyQBxyJDLfR:my.synapse.server/date/2022/07/29'` which is relative and was appended to the current URL.


### Solution

Now with the new code, we more clearly handle the 3 cases:

 - Normal Hydrogen `#/foo-bar` hash routing on the end of the URL
 - When `url=''` and we just need clear the Hydrogen hash route and maintain the current path and query parameters
 - An absolute URL which we can completely replace the page URL with
 
 
### Testing strategy

 - [x] From the room directory root `/`, search in the room directory (ensure query parameters maintained)
 - [x] From the room directory (`/?search=foo&homeserver=my.synapse.server`), open and close the "Add server" modal (ensure query parameters maintained and the modal hash appears and disappears respectively)
 - [x] Page-load the room directory with the "Add server" modal open (`/?search=foo&homeserver=my.synapse.server#/add-server`), ensure query parameters and hash maintained. Then hash disappears when closing the modal
 - [x] From the room archive page (`/!HBehERstyQBxyJDLfR:my.synapse.server/date/2022/09/20`), open and close the developer options modal (ensure modal hash appears and disappears respectively)
 - [x] From the room archive page with query parameters (`/!HBehERstyQBxyJDLfR:my.synapse.server/date/2022/09/20?via=my.synapse.server`), will page-load and then `?via=my.synapse.server` will disappear because we set the URL absolutely according to the date of the top-most event in view. The query parameter disappearing is ok as that was only for the homeserver initially joining anyway.
 - [x] Page-load the room archive page with the "Developer options" modal open (`/!HBehERstyQBxyJDLfR:my.synapse.server/date/2022/07/29#/developer-options`), ensure the hash maintained. Then hash disappears when closing the modal
 - [x] From the room archive page, ensure scrolling around changes the page URL according to the event dates you're scrolling in