### PR TITLE
Refactor to use `TimelineView`

### DIFF
--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -55,6 +55,13 @@ summary {
   min-width: 0;
 }
 
+.ArchiveRoomView_mainArea {
+  grid-area: middle;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+}
+
 .RoomHeader_actionButton {
   display: inline-flex;
   justify-content: center;
@@ -73,6 +80,19 @@ summary {
 /* No need to close the right-panel when it's always visible at desktop widths */
 .RightPanelView_buttons .close {
   display: none;
+}
+
+.ArchiveRoomView_mainBody {
+  flex: 1 1;
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  min-height: 0;
+  min-width: 0;
+}
+
+.ArchiveRoomView_mainBody > .Timeline {
+  flex: 1 0;
 }
 
 @media screen and (max-width: 800px) {
@@ -95,7 +115,7 @@ summary {
       'right' 1fr /
       1fr;
   }
-  .ArchiveRoomView.right-shown .middle {
+  .ArchiveRoomView.right-shown .ArchiveRoomView_mainArea {
     display: none;
   }
   /* And show the button to open the right-panel on mobile */

--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -59,6 +59,8 @@ summary {
   grid-area: middle;
   display: flex;
   flex-direction: column;
+  width: 100%;
+  min-width: 0;
   min-height: 0;
 }
 

--- a/shared/viewmodels/ArchiveRoomViewModel.js
+++ b/shared/viewmodels/ArchiveRoomViewModel.js
@@ -39,8 +39,6 @@ class ArchiveRoomViewModel extends ViewModel {
     const navigation = this.navigation;
     const urlCreator = this.urlCreator;
 
-    this._roomDirectoryUrl = this._matrixPublicArchiveURLCreator.roomDirectoryUrl();
-
     this._roomAvatarViewModel = new AvatarViewModel({
       homeserverUrlToPullMediaFrom: homeserverUrl,
       avatarUrl: this._room.avatarUrl,
@@ -212,7 +210,7 @@ class ArchiveRoomViewModel extends ViewModel {
   }
 
   get roomDirectoryUrl() {
-    return this._roomDirectoryUrl;
+    return this._matrixPublicArchiveURLCreator.roomDirectoryUrl();
   }
 
   get roomPermalink() {

--- a/shared/views/ArchiveRoomView.js
+++ b/shared/views/ArchiveRoomView.js
@@ -84,17 +84,21 @@ class RoomHeaderView extends TemplateView {
 
 class DisabledComposerView extends TemplateView {
   render(t, vm) {
-    const activeDate = new Date(
-      // If the date from our `archiveRoomViewModel` is available, use that
-      vm?.currentTopPositionEventEntry?.timestamp ||
-        // Otherwise, use our initial `dayTimestamp`
-        vm.dayTimestamp
-    );
-    const dateString = activeDate.toISOString().split('T')[0];
-
     return t.div({ className: 'DisabledComposerView' }, [
       t.h3([
-        `You're viewing an archive of events from ${dateString}. Use a `,
+        t.map(
+          (vm) => vm.currentTopPositionEventEntry,
+          (_currentTopPositionEventEntry, t, vm) => {
+            const activeDate = new Date(
+              // If the date from our `archiveRoomViewModel` is available, use that
+              vm?.currentTopPositionEventEntry?.timestamp ||
+                // Otherwise, use our initial `dayTimestamp`
+                vm.dayTimestamp
+            );
+            const dateString = activeDate.toISOString().split('T')[0];
+            return t.span(`You're viewing an archive of events from ${dateString}. Use a `);
+          }
+        ),
         t.a(
           {
             href: (vm) => vm.roomPermalink,

--- a/shared/views/ArchiveRoomView.js
+++ b/shared/views/ArchiveRoomView.js
@@ -3,7 +3,7 @@
 const {
   TemplateView,
   AvatarView,
-  RoomView,
+  TimelineView,
   RightPanelView,
   LightboxView,
 } = require('hydrogen-view-sdk');
@@ -43,8 +43,8 @@ class RoomHeaderView extends TemplateView {
           ),
         ]
       ),
-      t.view(new AvatarView(vm, 32)),
-      t.div({ className: 'room-description' }, [t.h2((vm) => vm.name)]),
+      t.view(new AvatarView(vm.roomAvatarViewModel, 32)),
+      t.div({ className: 'room-description' }, [t.h2((vm) => vm.roomName)]),
       t.button(
         {
           className: 'button-utility RoomHeader_actionButton RoomHeader_changeDatesButton',
@@ -82,6 +82,33 @@ class RoomHeaderView extends TemplateView {
   }
 }
 
+class DisabledComposerView extends TemplateView {
+  render(t, vm) {
+    const activeDate = new Date(
+      // If the date from our `archiveRoomViewModel` is available, use that
+      vm?.currentTopPositionEventEntry?.timestamp ||
+        // Otherwise, use our initial `dayTimestamp`
+        vm.dayTimestamp
+    );
+    const dateString = activeDate.toISOString().split('T')[0];
+
+    return t.div({ className: 'DisabledComposerView' }, [
+      t.h3([
+        `You're viewing an archive of events from ${dateString}. Use a `,
+        t.a(
+          {
+            href: (vm) => vm.roomPermalink,
+            rel: 'noopener',
+            target: '_blank',
+          },
+          ['Matrix client']
+        ),
+        ` to start chatting in this room.`,
+      ]),
+    ]);
+  }
+}
+
 class ArchiveRoomView extends TemplateView {
   render(t, vm) {
     const rootElement = t.div(
@@ -112,11 +139,15 @@ class ArchiveRoomView extends TemplateView {
             });
           }
         ),
-        t.view(
-          new RoomView(vm.roomViewModel, customViewClassForTile, {
-            RoomHeaderView,
-          })
-        ),
+        t.main({ className: 'ArchiveRoomView_mainArea' }, [
+          t.view(new RoomHeaderView(vm)),
+          t.main({ className: 'ArchiveRoomView_mainBody' }, [
+            t.view(
+              new TimelineView(vm.timelineViewModel, { viewClassForTile: customViewClassForTile })
+            ),
+            t.view(new DisabledComposerView(vm)),
+          ]),
+        ]),
         t.view(new RightPanelView(vm.rightPanelModel)),
         t.mapView(
           (vm) => vm.lightboxViewModel,

--- a/shared/views/ArchiveRoomView.js
+++ b/shared/views/ArchiveRoomView.js
@@ -83,7 +83,7 @@ class RoomHeaderView extends TemplateView {
 }
 
 class DisabledComposerView extends TemplateView {
-  render(t, vm) {
+  render(t /*, vm*/) {
     return t.div({ className: 'DisabledComposerView' }, [
       t.h3([
         t.map(

--- a/shared/views/ArchiveRoomView.js
+++ b/shared/views/ArchiveRoomView.js
@@ -146,9 +146,7 @@ class ArchiveRoomView extends TemplateView {
         t.main({ className: 'ArchiveRoomView_mainArea' }, [
           t.view(new RoomHeaderView(vm)),
           t.main({ className: 'ArchiveRoomView_mainBody' }, [
-            t.view(
-              new TimelineView(vm.timelineViewModel, { viewClassForTile: customViewClassForTile })
-            ),
+            t.view(new TimelineView(vm.timelineViewModel, customViewClassForTile)),
             t.view(new DisabledComposerView(vm)),
           ]),
         ]),


### PR DESCRIPTION
Refactor to use `TimelineView`. We have to figure out our own layout but does get rid of some of the `RoomView` boilerplate. The `TimelineView` still has outside boilerplate styles to work.

There shouldn't be any visible change:

environment | Before | After
--- | --- | ---
desktop | ![](https://user-images.githubusercontent.com/558581/199236829-6f882c59-7b30-4ea6-b547-817dc04fc815.png) | ![](https://user-images.githubusercontent.com/558581/199236799-97d40752-ec66-496b-8436-6017602e90e1.png)
mobile (right-panel collapsed) | ![](https://user-images.githubusercontent.com/558581/199237019-9a5f70da-69cf-4faa-94b2-ce137cdf2383.png) | ![](https://user-images.githubusercontent.com/558581/199237196-5216b673-bfa1-4281-bbee-5765daf3f28a.png)
mobile (right-panel expanded) | ![](https://user-images.githubusercontent.com/558581/199237036-5c4a4137-5463-41ff-a78f-38bb8a93a2bf.png) | ![](https://user-images.githubusercontent.com/558581/199237174-6db26b5a-7fd4-461a-bf7d-f3afb1ee7b89.png)










### Why are we switching from `RoomView` to `TimelineView`

> I continue to suspect that using `TimelineView` rather than `RoomView` would make more sense for your use case. In the future, `RoomView` will indeed evolve, but possibly in ways that don't simplify things for your use case. For example, we'll soon add support to show video calls in `RoomView`. We might add widget support some day. All things I imagine you have no need for. Because ... what you want to show is the timeline. The fact that you need to replace the room header already shows your needs are not exactly the same as a chat client.
IMO, having to implement the layout between the timeline, header and banner yourself is outweighed by your current need to mock the room view model completely, in ways that are bound to break in the future as the room UI allows more and more interactions not related to the timeline.
>
> *-- @bwindels, https://github.com/vector-im/hydrogen-web/pull/864#issuecomment-1282153269*

Also [aligns with what Chatterbox](https://github.com/vector-im/chatterbox/blob/ccdd8ffc905f766ef5952e8d1015bebdd0d433d8/src/ui/views/ChatterboxView.ts) has to do SDK wise. Our layout aligns more with Hydrogen which is why we originally used `RoomView` though.

Also a soft pre-requisite for https://github.com/matrix-org/matrix-public-archive/pull/114 so we can more easily pass options to `TimelineView` to change how the scroll works. Although we could work around and pass options through `RoomView` if necessary.


### Todo

 - [x] Make sure layout is the same on desktop
 - [x] Make sure layout is the same on mobile
 - [x] Make sure right panel expands and collapses and URL changes
 - [x] Make sure calendar updates as you scroll the timeline
 - [x] Make sure disabled composer date updates as you scroll the timeline
 - [ ] ~~Make sure the page loads with the timeline scrolled to the bottom~~
    - => Nevermind, this seems to be an existing problem as I can reproduce on `main` and previous revisions
    - Bugged behavior:
       <img src="https://user-images.githubusercontent.com/558581/199233960-bf119208-b5f9-4edd-abce-fe3e204b0c00.gif" width="455">
    - Seems to be offset by the height of the header (`.Timeline_scroller`, `$0.scrollHeight - $0.scrollTop - $0.clientHeight` = `56px`)
    - Doesn't occur on page refresh, only on a clean page load
