### PR TITLE
Refactor `fetchEndpointAsText`/`fetchEndpointAsJson` to return `res` alongside `data`

### DIFF
--- a/server/lib/fetch-endpoint.js
+++ b/server/lib/fetch-endpoint.js
@@ -43,7 +43,7 @@ async function fetchEndpoint(endpoint, options = {}) {
 async function fetchEndpointAsText(endpoint, options) {
   const res = await fetchEndpoint(endpoint, options);
   const data = await res.text();
-  return data;
+  return { data, res };
 }
 
 async function fetchEndpointAsJson(endpoint, options) {

--- a/server/lib/fetch-endpoint.js
+++ b/server/lib/fetch-endpoint.js
@@ -62,7 +62,7 @@ async function fetchEndpointAsJson(endpoint, options) {
 
   const res = await fetchEndpoint(endpoint, opts);
   const data = await res.json();
-  return data;
+  return { data, res };
 }
 
 module.exports = {

--- a/server/lib/matrix-utils/ensure-room-joined.js
+++ b/server/lib/matrix-utils/ensure-room-joined.js
@@ -21,7 +21,7 @@ async function ensureRoomJoined(accessToken, roomIdOrAlias, viaServers = []) {
     `_matrix/client/r0/join/${encodeURIComponent(roomIdOrAlias)}?${qs.toString()}`
   );
   try {
-    const joinData = await fetchEndpointAsJson(joinEndpoint, {
+    const { data: joinData } = await fetchEndpointAsJson(joinEndpoint, {
       method: 'POST',
       accessToken,
     });

--- a/server/lib/matrix-utils/fetch-public-rooms.js
+++ b/server/lib/matrix-utils/fetch-public-rooms.js
@@ -23,7 +23,7 @@ async function fetchPublicRooms(accessToken, { server, searchTerm, paginationTok
     `_matrix/client/v3/publicRooms?${qs.toString()}`
   );
 
-  const publicRoomsRes = await fetchEndpointAsJson(publicRoomsEndpoint, {
+  const { data: publicRoomsRes } = await fetchEndpointAsJson(publicRoomsEndpoint, {
     method: 'POST',
     body: {
       include_all_networks: true,

--- a/server/lib/matrix-utils/fetch-room-data.js
+++ b/server/lib/matrix-utils/fetch-room-data.js
@@ -36,11 +36,11 @@ async function fetchRoomData(accessToken, roomId) {
   );
 
   const [
-    stateNameResDataOutcome,
-    stateCanonicalAliasResDataOutcome,
-    stateAvatarResDataOutcome,
-    stateHistoryVisibilityResDataOutcome,
-    stateJoinRulesResDataOutcome,
+    { data: stateNameResDataOutcome },
+    { data: stateCanonicalAliasResDataOutcome },
+    { data: stateAvatarResDataOutcome },
+    { data: stateHistoryVisibilityResDataOutcome },
+    { data: stateJoinRulesResDataOutcome },
   ] = await Promise.allSettled([
     fetchEndpointAsJson(stateNameEndpoint, {
       accessToken,

--- a/server/lib/matrix-utils/fetch-room-data.js
+++ b/server/lib/matrix-utils/fetch-room-data.js
@@ -36,11 +36,11 @@ async function fetchRoomData(accessToken, roomId) {
   );
 
   const [
-    { data: stateNameResDataOutcome },
-    { data: stateCanonicalAliasResDataOutcome },
-    { data: stateAvatarResDataOutcome },
-    { data: stateHistoryVisibilityResDataOutcome },
-    { data: stateJoinRulesResDataOutcome },
+    stateNameResDataOutcome,
+    stateCanonicalAliasResDataOutcome,
+    stateAvatarResDataOutcome,
+    stateHistoryVisibilityResDataOutcome,
+    stateJoinRulesResDataOutcome,
   ] = await Promise.allSettled([
     fetchEndpointAsJson(stateNameEndpoint, {
       accessToken,
@@ -61,27 +61,32 @@ async function fetchRoomData(accessToken, roomId) {
 
   let name;
   if (stateNameResDataOutcome.reason === undefined) {
-    name = stateNameResDataOutcome.value.name;
+    const { data } = stateNameResDataOutcome.value;
+    name = data.name;
   }
 
   let canonicalAlias;
   if (stateCanonicalAliasResDataOutcome.reason === undefined) {
-    canonicalAlias = stateCanonicalAliasResDataOutcome.value.alias;
+    const { data } = stateCanonicalAliasResDataOutcome.value;
+    canonicalAlias = data.alias;
   }
 
   let avatarUrl;
   if (stateAvatarResDataOutcome.reason === undefined) {
-    avatarUrl = stateAvatarResDataOutcome.value.url;
+    const { data } = stateAvatarResDataOutcome.value;
+    avatarUrl = data.url;
   }
 
   let historyVisibility;
   if (stateHistoryVisibilityResDataOutcome.reason === undefined) {
-    historyVisibility = stateHistoryVisibilityResDataOutcome.value.history_visibility;
+    const { data } = stateHistoryVisibilityResDataOutcome.value;
+    historyVisibility = data.history_visibility;
   }
 
   let joinRule;
   if (stateJoinRulesResDataOutcome.reason === undefined) {
-    joinRule = stateJoinRulesResDataOutcome.value.join_rule;
+    const { data } = stateJoinRulesResDataOutcome.value;
+    joinRule = data.join_rule;
   }
 
   return {

--- a/server/lib/matrix-utils/get-messages-response-from-event-id.js
+++ b/server/lib/matrix-utils/get-messages-response-from-event-id.js
@@ -28,7 +28,7 @@ async function getMessagesResponseFromEventId({ accessToken, roomId, eventId, di
       eventId
     )}?limit=0&filter={"lazy_load_members":true}`
   );
-  const contextResData = await fetchEndpointAsJson(contextEndpoint, {
+  const { data: contextResData } = await fetchEndpointAsJson(contextEndpoint, {
     accessToken,
   });
 
@@ -42,7 +42,7 @@ async function getMessagesResponseFromEventId({ accessToken, roomId, eventId, di
       contextResData.end
     )}&limit=${limit}&filter={"lazy_load_members":true}`
   );
-  const messageResData = await fetchEndpointAsJson(messagesEndpoint, {
+  const { data: messageResData } = await fetchEndpointAsJson(messagesEndpoint, {
     accessToken,
   });
 

--- a/server/lib/matrix-utils/timestamp-to-event.js
+++ b/server/lib/matrix-utils/timestamp-to-event.js
@@ -22,7 +22,7 @@ async function timestampToEvent({ accessToken, roomId, ts, direction }) {
       roomId
     )}/timestamp_to_event?ts=${encodeURIComponent(ts)}&dir=${encodeURIComponent(direction)}`
   );
-  const timestampToEventResData = await fetchEndpointAsJson(timestampToEventEndpoint, {
+  const { data: timestampToEventResData } = await fetchEndpointAsJson(timestampToEventEndpoint, {
     accessToken,
   });
 

--- a/test/e2e-tests.js
+++ b/test/e2e-tests.js
@@ -190,7 +190,7 @@ describe('matrix-public-archive', () => {
         assert.strictEqual(eventIds.length, 3);
 
         archiveUrl = matrixPublicArchiveURLCreator.archiveUrlForDate(roomId, archiveDate);
-        const archivePageHtml = await fetchEndpointAsText(archiveUrl);
+        const { data: archivePageHtml } = await fetchEndpointAsText(archiveUrl);
 
         const dom = parseHTML(archivePageHtml);
 
@@ -358,7 +358,7 @@ describe('matrix-public-archive', () => {
 
         archiveUrl = matrixPublicArchiveURLCreator.archiveUrlForDate(roomId, archiveDate);
 
-        const archivePageHtml = await fetchEndpointAsText(archiveUrl);
+        const { data: archivePageHtml } = await fetchEndpointAsText(archiveUrl);
 
         const dom = parseHTML(archivePageHtml);
 
@@ -445,7 +445,7 @@ describe('matrix-public-archive', () => {
           viaServers: [HOMESERVER_URL_TO_PRETTY_NAME_MAP[testMatrixServerUrl2]],
         });
 
-        const archivePageHtml = await fetchEndpointAsText(archiveUrl);
+        const { data: archivePageHtml } = await fetchEndpointAsText(archiveUrl);
 
         const dom = parseHTML(archivePageHtml);
 
@@ -477,7 +477,7 @@ describe('matrix-public-archive', () => {
 
         // Visit `/:roomIdOrAlias` and expect to be redirected to the last day with events
         archiveUrl = matrixPublicArchiveURLCreator.archiveUrlForRoom(roomId);
-        const archivePageHtml = await fetchEndpointAsText(archiveUrl);
+        const { data: archivePageHtml } = await fetchEndpointAsText(archiveUrl);
 
         const dom = parseHTML(archivePageHtml);
 
@@ -516,7 +516,7 @@ describe('matrix-public-archive', () => {
           'The date we visit the archive (`visitArchiveDate`) should be after where the messages were sent (`archiveDate`)'
         );
         archiveUrl = matrixPublicArchiveURLCreator.archiveUrlForDate(roomId, visitArchiveDate);
-        const archivePageHtml = await fetchEndpointAsText(archiveUrl);
+        const { data: archivePageHtml } = await fetchEndpointAsText(archiveUrl);
 
         const dom = parseHTML(archivePageHtml);
 
@@ -545,7 +545,7 @@ describe('matrix-public-archive', () => {
         // We purposely send no events in the room
 
         archiveUrl = matrixPublicArchiveURLCreator.archiveUrlForDate(roomId, archiveDate);
-        const archivePageHtml = await fetchEndpointAsText(archiveUrl);
+        const { data: archivePageHtml } = await fetchEndpointAsText(archiveUrl);
 
         const dom = parseHTML(archivePageHtml);
 
@@ -574,7 +574,7 @@ describe('matrix-public-archive', () => {
         });
 
         archiveUrl = matrixPublicArchiveURLCreator.archiveUrlForDate(roomId, archiveDate);
-        const archivePageHtml = await fetchEndpointAsText(archiveUrl);
+        const { data: archivePageHtml } = await fetchEndpointAsText(archiveUrl);
 
         assert.match(archivePageHtml, /TODO: Redirect user to smaller hour range/);
       });
@@ -609,7 +609,7 @@ describe('matrix-public-archive', () => {
         });
 
         archiveUrl = matrixPublicArchiveURLCreator.archiveUrlForDate(roomId, archiveDate);
-        const archivePageHtml = await fetchEndpointAsText(archiveUrl);
+        const { data: archivePageHtml } = await fetchEndpointAsText(archiveUrl);
 
         const dom = parseHTML(archivePageHtml);
 
@@ -718,7 +718,7 @@ describe('matrix-public-archive', () => {
           );
           // Set this for debugging if the test fails here
           archiveUrl = firstPageArchiveUrl;
-          const firstPageArchivePageHtml = await fetchEndpointAsText(firstPageArchiveUrl);
+          const { data: firstPageArchivePageHtml } = await fetchEndpointAsText(firstPageArchiveUrl);
           const firstPageDom = parseHTML(firstPageArchivePageHtml);
 
           const eventIdsOnFirstPage = [...firstPageDom.document.querySelectorAll(`[data-event-id]`)]
@@ -746,7 +746,7 @@ describe('matrix-public-archive', () => {
           const nextActivityLink = nextActivityLinkEl.getAttribute('href');
           // Set this for debugging if the test fails here
           archiveUrl = nextActivityLink;
-          const nextActivityArchivePageHtml = await fetchEndpointAsText(nextActivityLink);
+          const { data: nextActivityArchivePageHtml } = await fetchEndpointAsText(nextActivityLink);
           const nextActivityDom = parseHTML(nextActivityArchivePageHtml);
 
           // Assert that it's a smooth continuation to more messages with no overlap
@@ -792,7 +792,7 @@ describe('matrix-public-archive', () => {
           );
           // Set this for debugging if the test fails here
           archiveUrl = firstPageArchiveUrl;
-          const firstPageArchivePageHtml = await fetchEndpointAsText(firstPageArchiveUrl);
+          const { data: firstPageArchivePageHtml } = await fetchEndpointAsText(firstPageArchiveUrl);
           const firstPageDom = parseHTML(firstPageArchivePageHtml);
 
           const eventIdsOnFirstPage = [...firstPageDom.document.querySelectorAll(`[data-event-id]`)]
@@ -820,7 +820,9 @@ describe('matrix-public-archive', () => {
           const previousActivityLink = previousActivityLinkEl.getAttribute('href');
           // Set this for debugging if the test fails here
           archiveUrl = previousActivityLink;
-          const previousActivityArchivePageHtml = await fetchEndpointAsText(previousActivityLink);
+          const { data: previousActivityArchivePageHtml } = await fetchEndpointAsText(
+            previousActivityLink
+          );
           const previousActivityDom = parseHTML(previousActivityArchivePageHtml);
 
           // Assert that it's a smooth continuation to more messages with no overlap
@@ -868,7 +870,7 @@ describe('matrix-public-archive', () => {
 
         // Browse the room directory without search to see many rooms
         archiveUrl = matrixPublicArchiveURLCreator.roomDirectoryUrl();
-        const roomDirectoryPageHtml = await fetchEndpointAsText(archiveUrl);
+        const { data: roomDirectoryPageHtml } = await fetchEndpointAsText(archiveUrl);
         const dom = parseHTML(roomDirectoryPageHtml);
 
         const roomsOnPageWithoutSearch = [
@@ -882,7 +884,7 @@ describe('matrix-public-archive', () => {
         archiveUrl = matrixPublicArchiveURLCreator.roomDirectoryUrl({
           searchTerm: roomPlanetPrefix,
         });
-        const roomDirectoryWithSearchPageHtml = await fetchEndpointAsText(archiveUrl);
+        const { data: roomDirectoryWithSearchPageHtml } = await fetchEndpointAsText(archiveUrl);
         const domWithSearch = parseHTML(roomDirectoryWithSearchPageHtml);
 
         const roomsOnPageWithSearch = [
@@ -919,7 +921,7 @@ describe('matrix-public-archive', () => {
           homeserver: HOMESERVER_URL_TO_PRETTY_NAME_MAP[testMatrixServerUrl2],
           searchTerm: roomPlanetPrefix,
         });
-        const roomDirectoryWithSearchPageHtml = await fetchEndpointAsText(archiveUrl);
+        const { data: roomDirectoryWithSearchPageHtml } = await fetchEndpointAsText(archiveUrl);
         const domWithSearch = parseHTML(roomDirectoryWithSearchPageHtml);
 
         // Make sure the `?homserver` is selected in the homeserver selector `<select>`
@@ -975,7 +977,7 @@ describe('matrix-public-archive', () => {
         const roomId = await createTestRoom(client);
 
         archiveUrl = matrixPublicArchiveURLCreator.archiveUrlForRoom(roomId);
-        const archivePageHtml = await fetchEndpointAsText(archiveUrl);
+        const { data: archivePageHtml } = await fetchEndpointAsText(archiveUrl);
 
         const dom = parseHTML(archivePageHtml);
 
@@ -994,7 +996,7 @@ describe('matrix-public-archive', () => {
         });
 
         archiveUrl = matrixPublicArchiveURLCreator.archiveUrlForRoom(roomId);
-        const archivePageHtml = await fetchEndpointAsText(archiveUrl);
+        const { data: archivePageHtml } = await fetchEndpointAsText(archiveUrl);
 
         const dom = parseHTML(archivePageHtml);
 

--- a/test/e2e-tests.js
+++ b/test/e2e-tests.js
@@ -83,7 +83,7 @@ describe('matrix-public-archive', () => {
         hs1Client.homeserverUrl,
         `_matrix/client/r0/rooms/${hs2RoomId}/messages?limit=5&dir=b&filter={"types":["m.room.message"]}`
       );
-      const messageResData = await fetchEndpointAsJson(messagesEndpoint, {
+      const { data: messageResData } = await fetchEndpointAsJson(messagesEndpoint, {
         accessToken: hs1Client.accessToken,
       });
 

--- a/test/lib/client-utils.js
+++ b/test/lib/client-utils.js
@@ -30,7 +30,7 @@ function slugify(inputText) {
 }
 
 async function ensureUserRegistered({ matrixServerUrl, username }) {
-  const registerResponse = await fetchEndpointAsJson(
+  const { data: registerResponse } = await fetchEndpointAsJson(
     urlJoin(matrixServerUrl, '/_matrix/client/v3/register'),
     {
       method: 'POST',
@@ -60,7 +60,7 @@ async function getTestClientForAs() {
 async function getTestClientForHs(testMatrixServerUrl) {
   // Register the virtual user
   const username = `user-t${new Date().getTime()}-r${Math.floor(Math.random() * 1000000000)}`;
-  const registerResponse = await fetchEndpointAsJson(
+  const { data: registerResponse } = await fetchEndpointAsJson(
     urlJoin(testMatrixServerUrl, '/_matrix/client/v3/register'),
     {
       method: 'POST',
@@ -95,7 +95,7 @@ async function createTestRoom(client, overrideCreateOptions = {}) {
   const roomName = overrideCreateOptions.name || 'the hangout spot';
   const roomAlias = slugify(roomName + getTxnId());
 
-  const createRoomResponse = await fetchEndpointAsJson(
+  const { data: createRoomResponse } = await fetchEndpointAsJson(
     urlJoin(client.homeserverUrl, `/_matrix/client/v3/createRoom?${qs.toString()}`),
     {
       method: 'POST',
@@ -125,7 +125,7 @@ async function createTestRoom(client, overrideCreateOptions = {}) {
 }
 
 async function getCanonicalAlias({ client, roomId }) {
-  const stateCanonicalAliasRes = await fetchEndpointAsJson(
+  const { data: stateCanonicalAliasRes } = await fetchEndpointAsJson(
     urlJoin(
       client.homeserverUrl,
       `_matrix/client/r0/rooms/${encodeURIComponent(roomId)}/state/m.room.canonical_alias`
@@ -157,7 +157,7 @@ async function joinRoom({ client, roomId, viaServers }) {
     client.homeserverUrl,
     `/_matrix/client/v3/join/${encodeURIComponent(roomId)}?${qs.toString()}`
   );
-  const joinRoomResponse = await fetchEndpointAsJson(joinRoomUrl, {
+  const { data: joinRoomResponse } = await fetchEndpointAsJson(joinRoomUrl, {
     method: 'POST',
     accessToken: client.accessToken,
   });
@@ -204,7 +204,7 @@ async function sendEvent({ client, roomId, eventType, stateKey, content, timesta
     );
   }
 
-  const sendResponse = await fetchEndpointAsJson(url, {
+  const { data: sendResponse } = await fetchEndpointAsJson(url, {
     method: 'PUT',
     body: content,
     accessToken: client.accessToken,


### PR DESCRIPTION
Refactor `fetchEndpointAsText`/`fetchEndpointAsJson` to return `res` alongside `data`

Split out of https://github.com/matrix-org/matrix-public-archive/pull/121
 where we needed to use `res.url`.