### PR TITLE
Updates to be compatible with the latest Hydrogen changes (rename `urlCreator` -> `urlRouter`)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "@opentelemetry/semantic-conventions": "^1.3.1",
         "dompurify": "^2.3.9",
         "express": "^4.17.2",
-        "hydrogen-view-sdk": "npm:@mlm/hydrogen-view-sdk@^0.23.0-scratch",
+        "hydrogen-view-sdk": "npm:@mlm/hydrogen-view-sdk@^0.24.0-scratch",
         "json5": "^2.2.1",
         "linkedom": "^0.14.17",
         "matrix-public-archive-shared": "file:./shared/",
@@ -3640,9 +3640,9 @@
     },
     "node_modules/hydrogen-view-sdk": {
       "name": "@mlm/hydrogen-view-sdk",
-      "version": "0.23.0-scratch",
-      "resolved": "https://registry.npmjs.org/@mlm/hydrogen-view-sdk/-/hydrogen-view-sdk-0.23.0-scratch.tgz",
-      "integrity": "sha512-YTA8kSFfvviTPThL3qh4kB6+nbOWDULHHM1DPf09rlwAFtOI7xPQwmEso+xNCMR5uMRspdSe5pkdbgO2jJQ0/Q==",
+      "version": "0.24.0-scratch",
+      "resolved": "https://registry.npmjs.org/@mlm/hydrogen-view-sdk/-/hydrogen-view-sdk-0.24.0-scratch.tgz",
+      "integrity": "sha512-NRH2TTjAaV+8siT6R4vAGJ55fSXT/7w5AdTe+mA6fyyTRKX2esWYFO+TtDSABm4TJmySqUxlUP/Yj+h1kuZ46w==",
       "dependencies": {
         "@matrix-org/olm": "https://gitlab.matrix.org/api/v4/projects/27/packages/npm/@matrix-org/olm/-/@matrix-org/olm-3.2.8.tgz",
         "another-json": "^0.2.0",
@@ -8091,9 +8091,9 @@
       }
     },
     "hydrogen-view-sdk": {
-      "version": "npm:@mlm/hydrogen-view-sdk@0.23.0-scratch",
-      "resolved": "https://registry.npmjs.org/@mlm/hydrogen-view-sdk/-/hydrogen-view-sdk-0.23.0-scratch.tgz",
-      "integrity": "sha512-YTA8kSFfvviTPThL3qh4kB6+nbOWDULHHM1DPf09rlwAFtOI7xPQwmEso+xNCMR5uMRspdSe5pkdbgO2jJQ0/Q==",
+      "version": "npm:@mlm/hydrogen-view-sdk@0.24.0-scratch",
+      "resolved": "https://registry.npmjs.org/@mlm/hydrogen-view-sdk/-/hydrogen-view-sdk-0.24.0-scratch.tgz",
+      "integrity": "sha512-NRH2TTjAaV+8siT6R4vAGJ55fSXT/7w5AdTe+mA6fyyTRKX2esWYFO+TtDSABm4TJmySqUxlUP/Yj+h1kuZ46w==",
       "requires": {
         "@matrix-org/olm": "https://gitlab.matrix.org/api/v4/projects/27/packages/npm/@matrix-org/olm/-/@matrix-org/olm-3.2.8.tgz",
         "another-json": "^0.2.0",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "@opentelemetry/semantic-conventions": "^1.3.1",
     "dompurify": "^2.3.9",
     "express": "^4.17.2",
-    "hydrogen-view-sdk": "npm:@mlm/hydrogen-view-sdk@^0.23.0-scratch",
+    "hydrogen-view-sdk": "npm:@mlm/hydrogen-view-sdk@^0.24.0-scratch",
     "json5": "^2.2.1",
     "linkedom": "^0.14.17",
     "matrix-public-archive-shared": "file:./shared/",

--- a/shared/hydrogen-vm-render-script.js
+++ b/shared/hydrogen-vm-render-script.js
@@ -118,7 +118,7 @@ async function mountHydrogen() {
     // Hydrogen options
     platform: platform,
     navigation: navigation,
-    urlCreator: urlRouter,
+    urlRouter: urlRouter,
     history: archiveHistory,
     // Our options
     homeserverUrl: config.matrixServerUrl,

--- a/shared/room-directory-vm-render-script.js
+++ b/shared/room-directory-vm-render-script.js
@@ -82,7 +82,7 @@ async function mountHydrogen() {
   roomDirectoryViewModel = new RoomDirectoryViewModel({
     // Hydrogen options
     navigation: navigation,
-    urlCreator: urlRouter,
+    urlRouter: urlRouter,
     history: archiveHistory,
     // Our options
     homeserverUrl: config.matrixServerUrl,

--- a/shared/viewmodels/ArchiveRoomViewModel.js
+++ b/shared/viewmodels/ArchiveRoomViewModel.js
@@ -87,7 +87,7 @@ class ArchiveRoomViewModel extends ViewModel {
     this._basePath = basePath;
 
     const navigation = this.navigation;
-    const urlCreator = this.urlCreator;
+    const urlRouter = this.urlRouter;
 
     // Setup events and tiles necessary to render
     const eventsToDisplay = this._addJumpSummaryEvents(events);
@@ -163,7 +163,7 @@ class ArchiveRoomViewModel extends ViewModel {
         calendarViewModel: this._calendarViewModel,
         shouldIndex,
         get developerOptionsUrl() {
-          return urlCreator.urlForSegments([
+          return urlRouter.urlForSegments([
             navigation.segment('room', room.id),
             navigation.segment('developer-options'),
           ]);
@@ -409,7 +409,7 @@ class ArchiveRoomViewModel extends ViewModel {
       tileClassForEntry: customTileClassForEntry,
       platform: this.platform,
       navigation: this.navigation,
-      urlCreator: this.urlCreator,
+      urlRouter: this.urlRouter,
       timeline,
       roomVM: {
         room,


### PR DESCRIPTION
Updates to be compatible with the latest Hydrogen changes (rename `urlCreator` -> `urlRouter`)

Hydrogen changes:

 - https://github.com/vector-im/hydrogen-web/pull/918
 
 
### TODO

 - [x] Update Hydrogen SDK dependency