### PR TITLE
Enable CORS support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "@opentelemetry/resources": "^1.3.1",
         "@opentelemetry/sdk-trace-base": "^1.3.1",
         "@opentelemetry/semantic-conventions": "^1.3.1",
+        "cors": "^2.8.5",
         "dompurify": "^2.3.9",
         "express": "^4.17.2",
         "hydrogen-view-sdk": "npm:@mlm/hydrogen-view-sdk@^0.25.0-scratch",
@@ -2531,6 +2532,18 @@
         "url": "https://opencollective.com/core-js"
       }
     },
+    "node_modules/cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
       "dev": true,
@@ -4461,6 +4474,14 @@
       },
       "funding": {
         "url": "https://github.com/fb55/nth-check?sponsor=1"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/off-color": {
@@ -7379,6 +7400,15 @@
     "core-js": {
       "version": "3.23.1"
     },
+    "cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "requires": {
+        "object-assign": "^4",
+        "vary": "^1"
+      }
+    },
     "cross-spawn": {
       "version": "7.0.3",
       "dev": true,
@@ -8585,6 +8615,11 @@
       "requires": {
         "boolbase": "^1.0.0"
       }
+    },
+    "object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="
     },
     "off-color": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "@opentelemetry/semantic-conventions": "^1.3.1",
     "dompurify": "^2.3.9",
     "express": "^4.17.2",
+    "cors": "^2.8.5",
     "hydrogen-view-sdk": "npm:@mlm/hydrogen-view-sdk@^0.25.0-scratch",
     "json5": "^2.2.1",
     "linkedom": "^0.14.17",

--- a/server/routes/install-routes.js
+++ b/server/routes/install-routes.js
@@ -2,6 +2,7 @@
 
 const path = require('path');
 const express = require('express');
+const cors = require('cors');
 const asyncHandler = require('../lib/express-async-handler');
 
 const { handleTracingMiddleware } = require('../tracing/tracing-middleware');
@@ -15,6 +16,7 @@ function installRoutes(app) {
   app.use(handleTracingMiddleware);
   app.use(preventClickjackingMiddleware);
   app.use(contentSecurityPolicyMiddleware);
+  app.use(cors());
 
   let healthCheckResponse;
   app.get(


### PR DESCRIPTION
This change enables CORS support in the archive — to allow web developers to create web applications with frontend JavaScript code that can fetch pages from the archive (for example, for scraping content from chat logs).

Otherwise, without this change, web developers can’t create web apps with frontend JavaScript that can fetch chat logs from the archive and then consume the content of the logs.

It’s imaginable that web developers may find use cases for consuming the chat logs in the archive from frontend JavaScript code — at the simplest level, web apps that fetch and scrape logs to get data out of them or to pull out particular snippets from the logs.

Developers can anyway already scrape the contents of the archive — by using server-side programming languages or by using `curl` or whatever from the command line. They just can’t do the same from frontend JavaScript code, unless CORS support is enabled.