### PR TITLE
Switch `/timestamp_to_event` endpoint to stable v1 #142

### DIFF
--- a/server/lib/matrix-utils/timestamp-to-event.js
+++ b/server/lib/matrix-utils/timestamp-to-event.js
@@ -18,7 +18,7 @@ async function timestampToEvent({ accessToken, roomId, ts, direction }) {
 
   const timestampToEventEndpoint = urlJoin(
     matrixServerUrl,
-    `_matrix/client/unstable/org.matrix.msc3030/rooms/${encodeURIComponent(
+    `_matrix/client/v1/rooms/${encodeURIComponent(
       roomId
     )}/timestamp_to_event?ts=${encodeURIComponent(ts)}&dir=${encodeURIComponent(direction)}`
   );


### PR DESCRIPTION
Relates to this issue:

- #142

Perhaps some of the README edits (and a default config comment) can be backed out or reworded that are part of this PR...

- #144

... but I'll leave it to someone who can word it better.