### PR TITLE
Update docs to reflect that we need stable MSC3030 `/timstamp_to_event`

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,16 +41,7 @@ the maintenance burden of supporting more event types in Hydrogen.
     for [Matrix encryption (olm) which can't be disabled in
     Hydrogen](https://github.com/vector-im/hydrogen-web/issues/579) yet.
 - A Matrix homeserver that supports [MSC3030's](https://github.com/matrix-org/matrix-spec-proposals/pull/3030) `/timestamp_to_event` endpoint
-  - Currently, the only implementation is in Synapse under an experimental feature flag.
-    Adjust your homeserver config to enable it:
-    `homeserver.yaml`
-    ```yaml
-    experimental_features:
-      msc3030_enabled: true
-    ```
-  - The `/timestamp_to_event` endpoint will soon be stabilized in Synapse which means
-    it will be available without the feature flag. You can track progress at
-    https://github.com/matrix-org/synapse/issues/14390
+  - Synapse 1.73.0+
 
 ### Get the app running
 

--- a/config/config.default.json
+++ b/config/config.default.json
@@ -1,7 +1,8 @@
 {
   "basePort": "3050",
   "basePath": "http://localhost:3050",
-  // Requires homeserver with MSC3030 `/timestamp_to_event` endpoint available (see readme for more details)
+  // Requires homeserver with MSC3030 `/timestamp_to_event` endpoint (Synapse 1.73.0+)
+  // (see readme for more details)
   "matrixServerUrl": "http://localhost:8008/",
   "matrixServerName": "localhost",
   // Set this to 100 since that is the max that Synapse will backfill even if you do a
@@ -15,7 +16,7 @@
 
   // Testing
   "testMatrixServerUrl1": "http://localhost:11008/",
-  "testMatrixServerUrl2": "http://localhost:12008/",
+  "testMatrixServerUrl2": "http://localhost:12008/"
 
   // Secrets
   //"matrixAccessToken": "xxx"


### PR DESCRIPTION
Update docs to reflect that we need stable MSC3030 /timstamp_to_event

Follow-up to https://github.com/matrix-org/matrix-public-archive/pull/154