### PR TITLE
Add preload link headers for downstream Cloudflare early hints (assets download before the page is rendered)

### DIFF
--- a/server/lib/set-headers-to-preload-assets.js
+++ b/server/lib/set-headers-to-preload-assets.js
@@ -1,0 +1,29 @@
+'use strict';
+
+const assert = require('assert');
+
+// Set some preload link headers which we can use with Cloudflare to turn into 103 early
+// hints, https://developers.cloudflare.com/cache/about/early-hints/
+//
+// This will turn into a nice speed-up since the server side render can take some time
+// while we fetch all the information from the homeserver and the page can have all of
+// the assets loaded and ready to go by that time. This way there is no extra delay
+// after the page gets served.
+function setHeadersToPreloadAssets(res, pageOptions) {
+  assert(res);
+  assert(pageOptions);
+
+  const { styles, scripts } = pageOptions;
+
+  const styleLinks = styles.map((styleUrl) => {
+    return `<${styleUrl}>; rel=preload; as=style`;
+  });
+
+  const scriptLinks = scripts.map((scriptUrl) => {
+    return `<${scriptUrl}>; rel=preload; as=script`;
+  });
+
+  res.append('Link', [].concat(styleLinks, scriptLinks).join(', '));
+}
+
+module.exports = setHeadersToPreloadAssets;


### PR DESCRIPTION
Add preload link headers for downstream [Cloudflare early hints](https://developers.cloudflare.com/cache/about/early-hints/). 

Because it takes us at best several seconds to request information from a homeserver and then server-side render the page, the browser has to wait for the response before it can even try loading the necessary assets. With this change that facilitates early hints, the browser can preload all of the assets necessary before we are done generating the response and will be ready to go by the time we're all done on the server.

Fix https://github.com/matrix-org/matrix-public-archive/issues/32

Part of https://github.com/matrix-org/matrix-public-archive/issues/132

Tracking actually enabling early hints in Cloudflare in the deployment issue: https://github.com/vector-im/sre-internal/issues/2079

---

To demonstrate the problem, see the waterfall 

Before | After
--- | ---
![](https://user-images.githubusercontent.com/558581/233176758-26683b39-0656-44d4-8527-b091a52a9dbc.png) | *I don't have an after visual because we haven't deployed with Cloudflare yet.* But it should move that chunk of asset loading after the page loads to before page starts loading so there is no delay in the page being responsive once we have serve a response.


### Dev notes

 - https://developers.cloudflare.com/cache/about/early-hints/
 - https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Link
 - https://blog.cloudflare.com/http-2-server-push-with-multiple-assets-per-link-header/