### PR TITLE
Serve Hydrogen assets from `/hydrogen-assets/` sub-directory for easier targeting of cache rules

### DIFF
--- a/server/routes/client-side-room-alias-hash-redirect-route.js
+++ b/server/routes/client-side-room-alias-hash-redirect-route.js
@@ -14,7 +14,7 @@ assert(basePath);
 // `/r/#room-alias:server/date/2022/10/27` -> `/r/room-alias:server/date/2022/10/27`
 function clientSideRoomAliasHashRedirectRoute(req, res) {
   const cspNonce = res.locals.cspNonce;
-  const hydrogenStylesUrl = urlJoin(basePath, '/hydrogen-styles.css');
+  const hydrogenStylesUrl = urlJoin(basePath, '/hydrogen-assets/hydrogen-styles.css');
   const stylesUrl = urlJoin(basePath, '/css/styles.css');
   const jsBundleUrl = urlJoin(basePath, '/js/entry-client-room-alias-hash-redirect.es.js');
 

--- a/server/routes/install-routes.js
+++ b/server/routes/install-routes.js
@@ -39,12 +39,15 @@ function installRoutes(app) {
   // We have to disable no-missing-require lint because it doesn't take into
   // account `package.json`. `exports`, see
   // https://github.com/mysticatea/eslint-plugin-node/issues/255
-  // eslint-disable-next-line node/no-missing-require
-  app.use(express.static(path.dirname(require.resolve('hydrogen-view-sdk/assets/main.js'))));
+  app.use(
+    '/hydrogen-assets',
+    // eslint-disable-next-line node/no-missing-require
+    express.static(path.dirname(require.resolve('hydrogen-view-sdk/assets/main.js')))
+  );
 
   app.get(
     // This has to be at the root so that the font URL references resolve correctly
-    '/hydrogen-styles.css',
+    '/hydrogen-assets/hydrogen-styles.css',
     asyncHandler(async function (req, res) {
       res.set('Content-Type', 'text/css');
       // We have to disable no-missing-require lint because it doesn't take into

--- a/server/routes/room-directory-routes.js
+++ b/server/routes/room-directory-routes.js
@@ -61,7 +61,7 @@ router.get(
     // We index the room directory unless the config says we shouldn't index anything
     const shouldIndex = !stopSearchEngineIndexing;
 
-    const hydrogenStylesUrl = urlJoin(basePath, '/hydrogen-styles.css');
+    const hydrogenStylesUrl = urlJoin(basePath, '/hydrogen-assets/hydrogen-styles.css');
     const stylesUrl = urlJoin(basePath, '/css/styles.css');
     const roomDirectoryStylesUrl = urlJoin(basePath, '/css/room-directory.css');
     const jsBundleUrl = urlJoin(basePath, '/js/entry-client-room-directory.es.js');

--- a/server/routes/room-routes.js
+++ b/server/routes/room-routes.js
@@ -865,7 +865,7 @@ router.get(
       shouldIndex = roomData?.historyVisibility === `world_readable`;
     }
 
-    const hydrogenStylesUrl = urlJoin(basePath, '/hydrogen-styles.css');
+    const hydrogenStylesUrl = urlJoin(basePath, '/hydrogen-assets/hydrogen-styles.css');
     const stylesUrl = urlJoin(basePath, '/css/styles.css');
     const jsBundleUrl = urlJoin(basePath, '/js/entry-client-hydrogen.es.js');
 

--- a/server/routes/timeout-middleware.js
+++ b/server/routes/timeout-middleware.js
@@ -50,7 +50,7 @@ async function timeoutMiddleware(req, res, next) {
 
     const cspNonce = res.locals.cspNonce;
 
-    const hydrogenStylesUrl = urlJoin(basePath, '/hydrogen-styles.css');
+    const hydrogenStylesUrl = urlJoin(basePath, '/hydrogen-assets/hydrogen-styles.css');
     const stylesUrl = urlJoin(basePath, '/css/styles.css');
 
     const pageHtml = `


### PR DESCRIPTION
Serve Hydrogen assets from `/hydrogen-assets/` sub-directory for easier targeting of cache rules

Fix https://github.com/matrix-org/matrix-public-archive/issues/160