### PR TITLE
Only read version tag files once on startup

### DIFF
--- a/server/lib/get-version-tags.js
+++ b/server/lib/get-version-tags.js
@@ -2,33 +2,31 @@
 
 const assert = require('assert');
 const path = require('path');
-const { readFile } = require('fs').promises;
+const fs = require('fs');
 
 const packageInfo = require('../../package.json');
 assert(packageInfo.version);
 
-async function getVersionTags() {
-  let commit;
-  let version;
-  let versionDate;
-  let packageVersion = packageInfo.version;
-  try {
-    [commit, version, versionDate] = await Promise.all([
-      readFile(path.join(__dirname, '../../dist/GIT_COMMIT'), 'utf8'),
-      readFile(path.join(__dirname, '../../dist/VERSION'), 'utf8'),
-      readFile(path.join(__dirname, '../../dist/VERSION_DATE'), 'utf8'),
-    ]);
-  } catch (err) {
-    console.warn('Unable to read version tags', err);
-    commit = 'Not specified';
-    version = 'Not specified';
-    versionDate = 'Not specified';
-  }
+const packageVersion = packageInfo.version;
 
+function readFileSync(path) {
+  try {
+    return fs.readFileSync(path, 'utf8');
+  } catch (err) {
+    console.warn(`Unable to read version tags path=${path}`, err);
+    return null;
+  }
+}
+
+const commit = readFileSync(path.join(__dirname, '../../dist/GIT_COMMIT'), 'utf8').trim();
+const version = readFileSync(path.join(__dirname, '../../dist/VERSION'), 'utf8').trim();
+const versionDate = readFileSync(path.join(__dirname, '../../dist/VERSION_DATE'), 'utf8').trim();
+
+function getVersionTags() {
   return {
-    commit: commit.trim(),
-    version: version.trim(),
-    versionDate: versionDate.trim(),
+    commit,
+    version,
+    versionDate,
     packageVersion,
   };
 }

--- a/server/routes/install-routes.js
+++ b/server/routes/install-routes.js
@@ -25,7 +25,7 @@ function installRoutes(app) {
     identifyRoute('health-check'),
     asyncHandler(async function (req, res) {
       if (!healthCheckResponse) {
-        const versionTags = await getVersionTags();
+        const versionTags = getVersionTags();
         const responseObject = {
           ok: true,
           ...versionTags,


### PR DESCRIPTION
Only read version tag files once on startup

No need to overload the disk with pesky askers.