### PR TITLE
Refactor codebase from CommonJS to ESM

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,15 +1,14 @@
 {
   "env": {
     "es6": true,
-    "commonjs": true,
     "node": true
   },
   "parserOptions": {
     "ecmaVersion": 2022,
-    "sourceType": "script"
+    "sourceType": "module"
   },
   "plugins": ["node"],
-  "extends": ["eslint:recommended", "prettier"],
+  "extends": ["eslint:recommended", "prettier", "plugin:node/recommended"],
   "rules": {
     "indent": "off",
     "comma-dangle": "off",
@@ -75,10 +74,6 @@
           "mode": "minimum"
         }
       }
-    ],
-    "node/no-missing-require": "error",
-    "node/no-missing-import": "error",
-    "node/no-unsupported-features/es-syntax": "error",
-    "node/no-unsupported-features/es-builtins": "error"
+    ]
   }
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -8,7 +8,7 @@
     "sourceType": "module"
   },
   "plugins": ["node"],
-  "extends": ["eslint:recommended", "prettier", "plugin:node/recommended"],
+  "extends": ["eslint:recommended", "prettier", "plugin:n/recommended"],
   "rules": {
     "indent": "off",
     "comma-dangle": "off",

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -15,7 +15,6 @@
     "comma-dangle": "off",
     "quotes": "off",
     "eqeqeq": ["warn", "allow-null"],
-    "strict": ["error", "safe"],
     "no-unused-vars": ["error", { "destructuredArrayIgnorePattern": "^_" }],
     "no-extra-boolean-cast": ["warn"],
     "complexity": [

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -7,7 +7,6 @@
     "ecmaVersion": 2022,
     "sourceType": "module"
   },
-  "plugins": ["node"],
   "extends": ["eslint:recommended", "prettier", "plugin:n/recommended"],
   "rules": {
     "indent": "off",

--- a/build-scripts/.eslintrc.json
+++ b/build-scripts/.eslintrc.json
@@ -1,0 +1,5 @@
+{
+  "rules": {
+    "node/no-unpublished-import": "off"
+  }
+}

--- a/build-scripts/.eslintrc.json
+++ b/build-scripts/.eslintrc.json
@@ -1,5 +1,5 @@
 {
   "rules": {
-    "node/no-unpublished-import": "off"
+    "n/no-unpublished-import": "off"
   }
 }

--- a/build-scripts/build-client-scripts.js
+++ b/build-scripts/build-client-scripts.js
@@ -8,12 +8,14 @@
 //  - https://github.com/vitejs/vite/issues/4530
 //  - https://github.com/vitejs/vite/discussions/1736
 
+import { fileURLToPath } from 'node:url';
 import path from 'path';
 import vite from 'vite';
 import mergeOptions from 'merge-options';
 
 import generateViteConfigForEntryPoint from './generate-vite-config-for-entry-point';
 
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const entryPoints = [
   path.resolve(__dirname, '../public/js/entry-client-hydrogen.js'),
   path.resolve(__dirname, '../public/js/entry-client-room-directory.js'),

--- a/build-scripts/build-client-scripts.js
+++ b/build-scripts/build-client-scripts.js
@@ -13,7 +13,7 @@ import path from 'path';
 import vite from 'vite';
 import mergeOptions from 'merge-options';
 
-import generateViteConfigForEntryPoint from './generate-vite-config-for-entry-point';
+import generateViteConfigForEntryPoint from './generate-vite-config-for-entry-point.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const entryPoints = [

--- a/build-scripts/build-client-scripts.js
+++ b/build-scripts/build-client-scripts.js
@@ -33,4 +33,4 @@ async function buildClientScripts(extraConfig = {}) {
   }
 }
 
-module.exports = buildClientScripts;
+export default buildClientScripts;

--- a/build-scripts/build-client-scripts.js
+++ b/build-scripts/build-client-scripts.js
@@ -1,5 +1,3 @@
-'use strict';
-
 // A way to build multiple Vite entrypoints
 
 // We can remove this once Vite supports multiple entrypoints and

--- a/build-scripts/build-client-scripts.js
+++ b/build-scripts/build-client-scripts.js
@@ -8,11 +8,11 @@
 //  - https://github.com/vitejs/vite/issues/4530
 //  - https://github.com/vitejs/vite/discussions/1736
 
-const path = require('path');
-const vite = require('vite');
-const mergeOptions = require('merge-options');
+import path from 'path';
+import vite from 'vite';
+import mergeOptions from 'merge-options';
 
-const generateViteConfigForEntryPoint = require('./generate-vite-config-for-entry-point');
+import generateViteConfigForEntryPoint from './generate-vite-config-for-entry-point';
 
 const entryPoints = [
   path.resolve(__dirname, '../public/js/entry-client-hydrogen.js'),

--- a/build-scripts/build-client.js
+++ b/build-scripts/build-client.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const buildClientScripts = require('./build-client-scripts');
 const writeVersionFiles = require('./write-version-files');
 

--- a/build-scripts/build-client.js
+++ b/build-scripts/build-client.js
@@ -1,5 +1,5 @@
-const buildClientScripts = require('./build-client-scripts');
-const writeVersionFiles = require('./write-version-files');
+import buildClientScripts from './build-client-scripts';
+import writeVersionFiles from './write-version-files';
 
 async function build(extraConfig) {
   await Promise.all([writeVersionFiles(), buildClientScripts(extraConfig)]);

--- a/build-scripts/build-client.js
+++ b/build-scripts/build-client.js
@@ -1,5 +1,5 @@
-import buildClientScripts from './build-client-scripts';
-import writeVersionFiles from './write-version-files';
+import buildClientScripts from './build-client-scripts.js';
+import writeVersionFiles from './write-version-files.js';
 
 async function build(extraConfig) {
   await Promise.all([writeVersionFiles(), buildClientScripts(extraConfig)]);

--- a/build-scripts/build-client.js
+++ b/build-scripts/build-client.js
@@ -5,4 +5,4 @@ async function build(extraConfig) {
   await Promise.all([writeVersionFiles(), buildClientScripts(extraConfig)]);
 }
 
-module.exports = build;
+export default build;

--- a/build-scripts/do-client-build.js
+++ b/build-scripts/do-client-build.js
@@ -1,5 +1,3 @@
-'use strict';
-
 // This is just a callable from the commandline version of `build-client.js`. So
 // that we can run the build from an npm script.
 

--- a/build-scripts/do-client-build.js
+++ b/build-scripts/do-client-build.js
@@ -1,6 +1,6 @@
 // This is just a callable from the commandline version of `build-client.js`. So
 // that we can run the build from an npm script.
 
-import buildClient from './build-client';
+import buildClient from './build-client.js';
 
 buildClient();

--- a/build-scripts/do-client-build.js
+++ b/build-scripts/do-client-build.js
@@ -1,6 +1,6 @@
 // This is just a callable from the commandline version of `build-client.js`. So
 // that we can run the build from an npm script.
 
-const buildClient = require('./build-client');
+import buildClient from './build-client';
 
 buildClient();

--- a/build-scripts/generate-vite-config-for-entry-point.js
+++ b/build-scripts/generate-vite-config-for-entry-point.js
@@ -1,6 +1,6 @@
 // vite.config.js
-const path = require('path');
-const { defineConfig } = require('vite');
+import path from 'path';
+import { defineConfig } from 'vite';
 
 function generateViteConfigForEntryPoint(entryPoint) {
   const entryPointName = path.basename(entryPoint, '.js');

--- a/build-scripts/generate-vite-config-for-entry-point.js
+++ b/build-scripts/generate-vite-config-for-entry-point.js
@@ -1,6 +1,9 @@
 // vite.config.js
+import { fileURLToPath } from 'node:url';
 import path from 'path';
 import { defineConfig } from 'vite';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 function generateViteConfigForEntryPoint(entryPoint) {
   const entryPointName = path.basename(entryPoint, '.js');

--- a/build-scripts/generate-vite-config-for-entry-point.js
+++ b/build-scripts/generate-vite-config-for-entry-point.js
@@ -39,4 +39,4 @@ function generateViteConfigForEntryPoint(entryPoint) {
   });
 }
 
-module.exports = generateViteConfigForEntryPoint;
+export default generateViteConfigForEntryPoint;

--- a/build-scripts/generate-vite-config-for-entry-point.js
+++ b/build-scripts/generate-vite-config-for-entry-point.js
@@ -1,6 +1,4 @@
 // vite.config.js
-'use strict';
-
 const path = require('path');
 const { defineConfig } = require('vite');
 

--- a/build-scripts/write-version-files.js
+++ b/build-scripts/write-version-files.js
@@ -1,6 +1,6 @@
-const path = require('path');
+import path from 'path';
 const { mkdir, writeFile } = require('fs').promises;
-const util = require('util');
+import util from 'util';
 const exec = util.promisify(require('child_process').exec);
 
 async function mkdirp(path) {

--- a/build-scripts/write-version-files.js
+++ b/build-scripts/write-version-files.js
@@ -2,7 +2,8 @@ import { fileURLToPath } from 'node:url';
 import path from 'path';
 import { mkdir, writeFile } from 'node:fs/promises';
 import util from 'util';
-const exec = util.promisify(require('child_process').exec);
+import { exec as _exec } from 'child_process';
+const exec = util.promisify(_exec);
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 

--- a/build-scripts/write-version-files.js
+++ b/build-scripts/write-version-files.js
@@ -42,4 +42,4 @@ async function writeVersionFiles() {
   await writeFile(path.join(__dirname, '../dist/VERSION_DATE'), new Date().toISOString());
 }
 
-module.exports = writeVersionFiles;
+export default writeVersionFiles;

--- a/build-scripts/write-version-files.js
+++ b/build-scripts/write-version-files.js
@@ -1,6 +1,6 @@
 import { fileURLToPath } from 'node:url';
 import path from 'path';
-const { mkdir, writeFile } = require('fs').promises;
+import { mkdir, writeFile } from 'node:fs/promises';
 import util from 'util';
 const exec = util.promisify(require('child_process').exec);
 

--- a/build-scripts/write-version-files.js
+++ b/build-scripts/write-version-files.js
@@ -1,7 +1,10 @@
+import { fileURLToPath } from 'node:url';
 import path from 'path';
 const { mkdir, writeFile } = require('fs').promises;
 import util from 'util';
 const exec = util.promisify(require('child_process').exec);
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 async function mkdirp(path) {
   try {

--- a/build-scripts/write-version-files.js
+++ b/build-scripts/write-version-files.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const path = require('path');
 const { mkdir, writeFile } = require('fs').promises;
 const util = require('util');

--- a/docker-health-check.js
+++ b/docker-health-check.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const assert = require('assert');
 
 const { fetchEndpointAsJson } = require('./server/lib/fetch-endpoint');

--- a/docker-health-check.js
+++ b/docker-health-check.js
@@ -1,8 +1,8 @@
-const assert = require('assert');
+import assert from 'assert';
 
-const { fetchEndpointAsJson } = require('./server/lib/fetch-endpoint');
+import { fetchEndpointAsJson } from './server/lib/fetch-endpoint';
 
-const config = require('./server/lib/config');
+import config from './server/lib/config';
 const basePort = config.get('basePort');
 assert(basePort);
 

--- a/docker-health-check.js
+++ b/docker-health-check.js
@@ -1,8 +1,8 @@
 import assert from 'assert';
 
-import { fetchEndpointAsJson } from './server/lib/fetch-endpoint';
+import { fetchEndpointAsJson } from './server/lib/fetch-endpoint.js';
 
-import config from './server/lib/config';
+import config from './server/lib/config.js';
 const basePort = config.get('basePort');
 assert(basePort);
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
         "escape-string-regexp": "^4.0.0",
         "eslint": "^8.37.0",
         "eslint-config-prettier": "^8.8.0",
-        "eslint-plugin-node": "^11.1.0",
+        "eslint-plugin-n": "^15.7.0",
         "eslint-plugin-prettier": "^4.2.1",
         "merge-options": "^3.0.4",
         "mocha": "^9.2.1",
@@ -2396,6 +2396,30 @@
         "node": ">= 0.10.x"
       }
     },
+    "node_modules/builtins": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/builtins/-/builtins-5.0.1.tgz",
+      "integrity": "sha512-qwVpFEHNfhYJIzNRBvd2C1kyo6jz3ZSMPyyuR47OPdiKWlbYnZNyDWuyR175qDnAJLiCo5fBBqPb3RiXgWlkOQ==",
+      "dev": true,
+      "dependencies": {
+        "semver": "^7.0.0"
+      }
+    },
+    "node_modules/builtins/node_modules/semver": {
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.0.tgz",
+      "integrity": "sha512-+XC0AD/R7Q2mPSRuy2Id0+CGTZ98+8f+KvwirxOKIEyid+XSx6HbC63p+O4IndTHuX5Z+JxQ0TghCkO5Cg/2HA==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/bytes": {
       "version": "3.1.1",
       "license": "MIT",
@@ -3038,9 +3062,10 @@
       }
     },
     "node_modules/eslint-plugin-es": {
-      "version": "3.0.1",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-es/-/eslint-plugin-es-4.1.0.tgz",
+      "integrity": "sha512-GILhQTnjYE2WorX5Jyi5i4dz5ALWxBIdQECVQavL6s7cI76IZTDWleTHkxz/QT3kvcs2QlGHvKLYsSlPOlPXnQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "eslint-utils": "^2.0.0",
         "regexpp": "^3.0.0"
@@ -3057,8 +3082,9 @@
     },
     "node_modules/eslint-plugin-es/node_modules/eslint-utils": {
       "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.1.0.tgz",
+      "integrity": "sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "eslint-visitor-keys": "^1.1.0"
       },
@@ -3071,52 +3097,51 @@
     },
     "node_modules/eslint-plugin-es/node_modules/eslint-visitor-keys": {
       "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
+      "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
       "dev": true,
-      "license": "Apache-2.0",
       "engines": {
         "node": ">=4"
       }
     },
-    "node_modules/eslint-plugin-node": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-node/-/eslint-plugin-node-11.1.0.tgz",
-      "integrity": "sha512-oUwtPJ1W0SKD0Tr+wqu92c5xuCeQqB3hSCHasn/ZgjFdA9iDGNkNf2Zi9ztY7X+hNuMib23LNGRm6+uN+KLE3g==",
+    "node_modules/eslint-plugin-n": {
+      "version": "15.7.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-n/-/eslint-plugin-n-15.7.0.tgz",
+      "integrity": "sha512-jDex9s7D/Qial8AGVIHq4W7NswpUD5DPDL2RH8Lzd9EloWUuvUkHfv4FRLMipH5q2UtyurorBkPeNi1wVWNh3Q==",
       "dev": true,
       "dependencies": {
-        "eslint-plugin-es": "^3.0.0",
-        "eslint-utils": "^2.0.0",
+        "builtins": "^5.0.1",
+        "eslint-plugin-es": "^4.1.0",
+        "eslint-utils": "^3.0.0",
         "ignore": "^5.1.1",
-        "minimatch": "^3.0.4",
-        "resolve": "^1.10.1",
-        "semver": "^6.1.0"
+        "is-core-module": "^2.11.0",
+        "minimatch": "^3.1.2",
+        "resolve": "^1.22.1",
+        "semver": "^7.3.8"
       },
       "engines": {
-        "node": ">=8.10.0"
-      },
-      "peerDependencies": {
-        "eslint": ">=5.16.0"
-      }
-    },
-    "node_modules/eslint-plugin-node/node_modules/eslint-utils": {
-      "version": "2.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "eslint-visitor-keys": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=6"
+        "node": ">=12.22.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/mysticatea"
+      },
+      "peerDependencies": {
+        "eslint": ">=7.0.0"
       }
     },
-    "node_modules/eslint-plugin-node/node_modules/eslint-visitor-keys": {
-      "version": "1.3.0",
+    "node_modules/eslint-plugin-n/node_modules/semver": {
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.0.tgz",
+      "integrity": "sha512-+XC0AD/R7Q2mPSRuy2Id0+CGTZ98+8f+KvwirxOKIEyid+XSx6HbC63p+O4IndTHuX5Z+JxQ0TghCkO5Cg/2HA==",
       "dev": true,
-      "license": "Apache-2.0",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
       "engines": {
-        "node": ">=4"
+        "node": ">=10"
       }
     },
     "node_modules/eslint-plugin-prettier": {
@@ -3151,6 +3176,33 @@
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/eslint-utils": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
+      "integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
+      "dev": true,
+      "dependencies": {
+        "eslint-visitor-keys": "^2.0.0"
+      },
+      "engines": {
+        "node": "^10.0.0 || ^12.0.0 || >= 14.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mysticatea"
+      },
+      "peerDependencies": {
+        "eslint": ">=5"
+      }
+    },
+    "node_modules/eslint-utils/node_modules/eslint-visitor-keys": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
+      "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/eslint-visitor-keys": {
@@ -3873,8 +3925,9 @@
       }
     },
     "node_modules/is-core-module": {
-      "version": "2.8.1",
-      "license": "MIT",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.12.0.tgz",
+      "integrity": "sha512-RECHCBCd/viahWmwj6enj19sKbHfJrddi/6cBDsNTKbNq0f7VeaUkBo60BqzvPqo/W54ChS62Z5qyun7cfOMqQ==",
       "dependencies": {
         "has": "^1.0.3"
       },
@@ -5075,8 +5128,9 @@
     },
     "node_modules/regexpp": {
       "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
+      "integrity": "sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=8"
       },
@@ -5149,10 +5203,11 @@
       "license": "MIT"
     },
     "node_modules/resolve": {
-      "version": "1.22.0",
-      "license": "MIT",
+      "version": "1.22.2",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.2.tgz",
+      "integrity": "sha512-Sb+mjNHOULsBv818T40qSPeRiuWLyaGMa5ewydRLFimneixmVy2zdivRl+AF6jaYPC8ERxGDmFSiqui6SfPd+g==",
       "dependencies": {
-        "is-core-module": "^2.8.1",
+        "is-core-module": "^2.11.0",
         "path-parse": "^1.0.7",
         "supports-preserve-symlinks-flag": "^1.0.0"
       },
@@ -7456,6 +7511,26 @@
         "xtend": "^4.0.0"
       }
     },
+    "builtins": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/builtins/-/builtins-5.0.1.tgz",
+      "integrity": "sha512-qwVpFEHNfhYJIzNRBvd2C1kyo6jz3ZSMPyyuR47OPdiKWlbYnZNyDWuyR175qDnAJLiCo5fBBqPb3RiXgWlkOQ==",
+      "dev": true,
+      "requires": {
+        "semver": "^7.0.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "7.5.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.0.tgz",
+          "integrity": "sha512-+XC0AD/R7Q2mPSRuy2Id0+CGTZ98+8f+KvwirxOKIEyid+XSx6HbC63p+O4IndTHuX5Z+JxQ0TghCkO5Cg/2HA==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        }
+      }
+    },
     "bytes": {
       "version": "3.1.1"
     },
@@ -7884,7 +7959,9 @@
       "requires": {}
     },
     "eslint-plugin-es": {
-      "version": "3.0.1",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-es/-/eslint-plugin-es-4.1.0.tgz",
+      "integrity": "sha512-GILhQTnjYE2WorX5Jyi5i4dz5ALWxBIdQECVQavL6s7cI76IZTDWleTHkxz/QT3kvcs2QlGHvKLYsSlPOlPXnQ==",
       "dev": true,
       "requires": {
         "eslint-utils": "^2.0.0",
@@ -7893,6 +7970,8 @@
       "dependencies": {
         "eslint-utils": {
           "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.1.0.tgz",
+          "integrity": "sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==",
           "dev": true,
           "requires": {
             "eslint-visitor-keys": "^1.1.0"
@@ -7900,34 +7979,36 @@
         },
         "eslint-visitor-keys": {
           "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
+          "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
           "dev": true
         }
       }
     },
-    "eslint-plugin-node": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-node/-/eslint-plugin-node-11.1.0.tgz",
-      "integrity": "sha512-oUwtPJ1W0SKD0Tr+wqu92c5xuCeQqB3hSCHasn/ZgjFdA9iDGNkNf2Zi9ztY7X+hNuMib23LNGRm6+uN+KLE3g==",
+    "eslint-plugin-n": {
+      "version": "15.7.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-n/-/eslint-plugin-n-15.7.0.tgz",
+      "integrity": "sha512-jDex9s7D/Qial8AGVIHq4W7NswpUD5DPDL2RH8Lzd9EloWUuvUkHfv4FRLMipH5q2UtyurorBkPeNi1wVWNh3Q==",
       "dev": true,
       "requires": {
-        "eslint-plugin-es": "^3.0.0",
-        "eslint-utils": "^2.0.0",
+        "builtins": "^5.0.1",
+        "eslint-plugin-es": "^4.1.0",
+        "eslint-utils": "^3.0.0",
         "ignore": "^5.1.1",
-        "minimatch": "^3.0.4",
-        "resolve": "^1.10.1",
-        "semver": "^6.1.0"
+        "is-core-module": "^2.11.0",
+        "minimatch": "^3.1.2",
+        "resolve": "^1.22.1",
+        "semver": "^7.3.8"
       },
       "dependencies": {
-        "eslint-utils": {
-          "version": "2.1.0",
+        "semver": {
+          "version": "7.5.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.0.tgz",
+          "integrity": "sha512-+XC0AD/R7Q2mPSRuy2Id0+CGTZ98+8f+KvwirxOKIEyid+XSx6HbC63p+O4IndTHuX5Z+JxQ0TghCkO5Cg/2HA==",
           "dev": true,
           "requires": {
-            "eslint-visitor-keys": "^1.1.0"
+            "lru-cache": "^6.0.0"
           }
-        },
-        "eslint-visitor-keys": {
-          "version": "1.3.0",
-          "dev": true
         }
       }
     },
@@ -7948,6 +8029,23 @@
       "requires": {
         "esrecurse": "^4.3.0",
         "estraverse": "^5.2.0"
+      }
+    },
+    "eslint-utils": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
+      "integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
+      "dev": true,
+      "requires": {
+        "eslint-visitor-keys": "^2.0.0"
+      },
+      "dependencies": {
+        "eslint-visitor-keys": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
+          "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
+          "dev": true
+        }
       }
     },
     "eslint-visitor-keys": {
@@ -8409,7 +8507,9 @@
       }
     },
     "is-core-module": {
-      "version": "2.8.1",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.12.0.tgz",
+      "integrity": "sha512-RECHCBCd/viahWmwj6enj19sKbHfJrddi/6cBDsNTKbNq0f7VeaUkBo60BqzvPqo/W54ChS62Z5qyun7cfOMqQ==",
       "requires": {
         "has": "^1.0.3"
       }
@@ -9133,6 +9233,8 @@
     },
     "regexpp": {
       "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
+      "integrity": "sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==",
       "dev": true
     },
     "registry-auth-token": {
@@ -9175,9 +9277,11 @@
       }
     },
     "resolve": {
-      "version": "1.22.0",
+      "version": "1.22.2",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.2.tgz",
+      "integrity": "sha512-Sb+mjNHOULsBv818T40qSPeRiuWLyaGMa5ewydRLFimneixmVy2zdivRl+AF6jaYPC8ERxGDmFSiqui6SfPd+g==",
       "requires": {
-        "is-core-module": "^2.8.1",
+        "is-core-module": "^2.11.0",
         "path-parse": "^1.0.7",
         "supports-preserve-symlinks-flag": "^1.0.0"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "@opentelemetry/semantic-conventions": "^1.3.1",
         "cors": "^2.8.5",
         "dompurify": "^2.3.9",
+        "escape-string-regexp": "^5.0.0",
         "express": "^4.17.2",
         "hydrogen-view-sdk": "npm:@mlm/hydrogen-view-sdk@^0.25.0-scratch",
         "json5": "^2.2.1",
@@ -32,7 +33,6 @@
       },
       "devDependencies": {
         "chalk": "^4.1.2",
-        "escape-string-regexp": "^4.0.0",
         "eslint": "^8.37.0",
         "eslint-config-prettier": "^8.8.0",
         "eslint-plugin-n": "^15.7.0",
@@ -2981,12 +2981,11 @@
       "license": "MIT"
     },
     "node_modules/escape-string-regexp": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
-      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-      "dev": true,
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
       "engines": {
-        "node": ">=10"
+        "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -3231,6 +3230,18 @@
         "supports-color": {
           "optional": true
         }
+      }
+    },
+    "node_modules/eslint/node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/eslint/node_modules/ms": {
@@ -4413,6 +4424,18 @@
       "version": "2.1.2",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/mocha/node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/mocha/node_modules/minimatch": {
       "version": "3.0.4",
@@ -7885,10 +7908,9 @@
       "version": "1.0.3"
     },
     "escape-string-regexp": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
-      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-      "dev": true
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw=="
     },
     "eslint": {
       "version": "8.37.0",
@@ -7944,6 +7966,12 @@
           "requires": {
             "ms": "2.1.2"
           }
+        },
+        "escape-string-regexp": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+          "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+          "dev": true
         },
         "ms": {
           "version": "2.1.2",
@@ -8809,6 +8837,12 @@
               "dev": true
             }
           }
+        },
+        "escape-string-regexp": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+          "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+          "dev": true
         },
         "minimatch": {
           "version": "3.0.4",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
   },
   "devDependencies": {
     "chalk": "^4.1.2",
-    "escape-string-regexp": "^4.0.0",
     "eslint": "^8.37.0",
     "eslint-config-prettier": "^8.8.0",
     "eslint-plugin-n": "^15.7.0",
@@ -49,6 +48,7 @@
     "@opentelemetry/semantic-conventions": "^1.3.1",
     "cors": "^2.8.5",
     "dompurify": "^2.3.9",
+    "escape-string-regexp": "^5.0.0",
     "express": "^4.17.2",
     "hydrogen-view-sdk": "npm:@mlm/hydrogen-view-sdk@^0.25.0-scratch",
     "json5": "^2.2.1",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "escape-string-regexp": "^4.0.0",
     "eslint": "^8.37.0",
     "eslint-config-prettier": "^8.8.0",
-    "eslint-plugin-node": "^11.1.0",
+    "eslint-plugin-n": "^15.7.0",
     "eslint-plugin-prettier": "^4.2.1",
     "merge-options": "^3.0.4",
     "mocha": "^9.2.1",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "eslint": "eslint",
     "prettier": "prettier"
   },
+  "type": "module",
   "engines": {
     "node": ">=16.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "lint": "eslint **/*.js",
     "build": "node ./build-scripts/do-client-build.js",
-    "start": "node server/server.js",
+    "start": "node --experimental-vm-modules server/server.js",
     "start-dev": "node server/start-dev.js",
     "test": "npm run mocha -- test/**/*-tests.js --timeout 15000",
     "test-e2e-interactive": "npm run mocha -- test/e2e-tests.js --timeout 15000 --bail --interactive",

--- a/public/js/.eslintrc.json
+++ b/public/js/.eslintrc.json
@@ -1,15 +1,10 @@
 {
   "env": {
     "browser": true,
-    "commonjs": false,
     "node": false
   },
   "parserOptions": {
     "ecmaVersion": 2018,
     "sourceType": "module"
-  },
-  "rules": {
-    "node/no-unsupported-features/es-syntax": "off",
-    "node/no-unsupported-features/es-builtins": "off"
   }
 }

--- a/public/js/entry-client-hydrogen.js
+++ b/public/js/entry-client-hydrogen.js
@@ -1,1 +1,1 @@
-import 'matrix-public-archive-shared/hydrogen-vm-render-script';
+import 'matrix-public-archive-shared/hydrogen-vm-render-script.js';

--- a/public/js/entry-client-room-alias-hash-redirect.js
+++ b/public/js/entry-client-room-alias-hash-redirect.js
@@ -1,6 +1,6 @@
-import assert from 'matrix-public-archive-shared/lib/assert';
-import MatrixPublicArchiveURLCreator from 'matrix-public-archive-shared/lib/url-creator';
-import redirectIfRoomAliasInHash from 'matrix-public-archive-shared/lib/redirect-if-room-alias-in-hash';
+import assert from 'matrix-public-archive-shared/lib/assert.js';
+import MatrixPublicArchiveURLCreator from 'matrix-public-archive-shared/lib/url-creator.js';
+import redirectIfRoomAliasInHash from 'matrix-public-archive-shared/lib/redirect-if-room-alias-in-hash.js';
 
 const config = window.matrixPublicArchiveContext.config;
 assert(config);

--- a/public/js/entry-client-room-directory.js
+++ b/public/js/entry-client-room-directory.js
@@ -1,1 +1,1 @@
-import 'matrix-public-archive-shared/room-directory-vm-render-script';
+import 'matrix-public-archive-shared/room-directory-vm-render-script.js';

--- a/server/child-process-runner/child-fork-script.js
+++ b/server/child-process-runner/child-fork-script.js
@@ -66,7 +66,7 @@ process.on('message', async (runArguments) => {
 
     // Run the module
     const moduleToRun = await import(modulePath);
-    const result = await moduleToRun(runArguments);
+    const result = await moduleToRun.default(runArguments);
 
     assert(result, `No result returned from module we ran (${modulePath}).`);
 

--- a/server/child-process-runner/child-fork-script.js
+++ b/server/child-process-runner/child-fork-script.js
@@ -1,5 +1,3 @@
-'use strict';
-
 // Called by `child_process` `fork` in `run-in-child-process.js` so we can
 // get the data and exit the process cleanly.
 

--- a/server/child-process-runner/child-fork-script.js
+++ b/server/child-process-runner/child-fork-script.js
@@ -63,9 +63,9 @@ process.on('message', async (runArguments) => {
       modulePath,
       'Expected `modulePath` to be passed into `child-fork-script.js` via argv[2]'
     );
-    import moduleToRun from modulePath;
 
     // Run the module
+    const moduleToRun = await import(modulePath);
     const result = await moduleToRun(runArguments);
 
     assert(result, `No result returned from module we ran (${modulePath}).`);

--- a/server/child-process-runner/child-fork-script.js
+++ b/server/child-process-runner/child-fork-script.js
@@ -3,7 +3,7 @@
 
 import assert from 'assert';
 
-import RethrownError from '../lib/rethrown-error';
+import RethrownError from '../lib/rethrown-error.js';
 
 // Serialize the error and send it back up to the parent process so we can
 // interact with it and know what happened when the process exits.

--- a/server/child-process-runner/child-fork-script.js
+++ b/server/child-process-runner/child-fork-script.js
@@ -1,9 +1,9 @@
 // Called by `child_process` `fork` in `run-in-child-process.js` so we can
 // get the data and exit the process cleanly.
 
-const assert = require('assert');
+import assert from 'assert';
 
-const RethrownError = require('../lib/rethrown-error');
+import RethrownError from '../lib/rethrown-error';
 
 // Serialize the error and send it back up to the parent process so we can
 // interact with it and know what happened when the process exits.
@@ -63,7 +63,7 @@ process.on('message', async (runArguments) => {
       modulePath,
       'Expected `modulePath` to be passed into `child-fork-script.js` via argv[2]'
     );
-    const moduleToRun = require(modulePath);
+    import moduleToRun from modulePath;
 
     // Run the module
     const result = await moduleToRun(runArguments);

--- a/server/child-process-runner/run-in-child-process.js
+++ b/server/child-process-runner/run-in-child-process.js
@@ -7,13 +7,13 @@
 // `unhandledRejection` to give more context if the process exits with code 1
 // (error) or timesout.
 
-const assert = require('assert');
-const { fork } = require('child_process');
+import assert from 'assert';
+import { fork } from 'child_process';
 
-const RethrownError = require('../lib/rethrown-error');
-const { traceFunction } = require('../tracing/trace-utilities');
+import RethrownError from '../lib/rethrown-error';
+import { traceFunction } from '../tracing/trace-utilities';
 
-const config = require('../lib/config');
+import config from '../lib/config';
 const logOutputFromChildProcesses = config.get('logOutputFromChildProcesses');
 
 if (!logOutputFromChildProcesses) {

--- a/server/child-process-runner/run-in-child-process.js
+++ b/server/child-process-runner/run-in-child-process.js
@@ -10,10 +10,10 @@
 import assert from 'assert';
 import { fork } from 'child_process';
 
-import RethrownError from '../lib/rethrown-error';
-import { traceFunction } from '../tracing/trace-utilities';
+import RethrownError from '../lib/rethrown-error.js';
+import { traceFunction } from '../tracing/trace-utilities.js';
 
-import config from '../lib/config';
+import config from '../lib/config.js';
 const logOutputFromChildProcesses = config.get('logOutputFromChildProcesses');
 
 if (!logOutputFromChildProcesses) {

--- a/server/child-process-runner/run-in-child-process.js
+++ b/server/child-process-runner/run-in-child-process.js
@@ -9,7 +9,6 @@
 
 import assert from 'assert';
 import { fork } from 'child_process';
-import { createRequire } from 'node:module';
 
 import RethrownError from '../lib/rethrown-error.js';
 import { traceFunction } from '../tracing/trace-utilities.js';
@@ -17,8 +16,7 @@ import { traceFunction } from '../tracing/trace-utilities.js';
 import config from '../lib/config.js';
 const logOutputFromChildProcesses = config.get('logOutputFromChildProcesses');
 
-const require = createRequire(import.meta.url);
-const childForkScriptModulePath = require.resolve('./child-fork-script');
+const childForkScriptModulePath = new URL('./child-fork-script', import.meta.url);
 
 if (!logOutputFromChildProcesses) {
   console.warn(

--- a/server/child-process-runner/run-in-child-process.js
+++ b/server/child-process-runner/run-in-child-process.js
@@ -174,4 +174,4 @@ async function runInChildProcess(modulePath, runArguments, { timeout }) {
   }
 }
 
-module.exports = traceFunction(runInChildProcess);
+export default traceFunction(runInChildProcess);

--- a/server/child-process-runner/run-in-child-process.js
+++ b/server/child-process-runner/run-in-child-process.js
@@ -1,5 +1,3 @@
-'use strict';
-
 // Generic `child_process` runner that handles running the given module with the
 // given `runArguments` and returning the async result. Handles the complexity
 // error handling, passing large argument objects, and timeouts.

--- a/server/child-process-runner/run-in-child-process.js
+++ b/server/child-process-runner/run-in-child-process.js
@@ -9,12 +9,16 @@
 
 import assert from 'assert';
 import { fork } from 'child_process';
+import { createRequire } from 'node:module';
 
 import RethrownError from '../lib/rethrown-error.js';
 import { traceFunction } from '../tracing/trace-utilities.js';
 
 import config from '../lib/config.js';
 const logOutputFromChildProcesses = config.get('logOutputFromChildProcesses');
+
+const require = createRequire(import.meta.url);
+const childForkScriptModulePath = require.resolve('./child-fork-script');
 
 if (!logOutputFromChildProcesses) {
   console.warn(
@@ -70,7 +74,7 @@ async function runInChildProcess(modulePath, runArguments, { timeout }) {
     // We use a child_process because we want to be able to exit the process
     // after we receive the results. We use `fork` instead of `exec`/`spawn` so
     // that we can pass a module instead of running a command.
-    const child = fork(require.resolve('./child-fork-script'), [modulePath], {
+    const child = fork(childForkScriptModulePath, [modulePath], {
       signal,
       // Default to silencing logs from the child process. We already have
       // proper instrumentation of any errors that might occur.

--- a/server/hydrogen-render/render-hydrogen-to-string-unsafe.js
+++ b/server/hydrogen-render/render-hydrogen-to-string-unsafe.js
@@ -12,7 +12,7 @@
 import assert from 'assert';
 import vm from 'vm';
 import path from 'path';
-const { readFile } = require('fs').promises;
+import { readFile } from 'node:fs/promises';
 import crypto from 'crypto';
 import { parseHTML } from 'linkedom';
 

--- a/server/hydrogen-render/render-hydrogen-to-string-unsafe.js
+++ b/server/hydrogen-render/render-hydrogen-to-string-unsafe.js
@@ -115,4 +115,4 @@ async function _renderHydrogenToStringUnsafe(renderOptions) {
   return documentString;
 }
 
-module.exports = _renderHydrogenToStringUnsafe;
+export default _renderHydrogenToStringUnsafe;

--- a/server/hydrogen-render/render-hydrogen-to-string-unsafe.js
+++ b/server/hydrogen-render/render-hydrogen-to-string-unsafe.js
@@ -1,5 +1,3 @@
-'use strict';
-
 // Server-side render Hydrogen to a string using a browser-like context thanks
 // to `linkedom`. We use a VM so we can put all of the browser-like globals in
 // place.

--- a/server/hydrogen-render/render-hydrogen-to-string-unsafe.js
+++ b/server/hydrogen-render/render-hydrogen-to-string-unsafe.js
@@ -9,12 +9,12 @@
 // This is why we have the `1-render-hydrogen-to-string.js` layer to handle
 // this.
 
-const assert = require('assert');
-const vm = require('vm');
-const path = require('path');
+import assert from 'assert';
+import vm from 'vm';
+import path from 'path';
 const { readFile } = require('fs').promises;
-const crypto = require('crypto');
-const { parseHTML } = require('linkedom');
+import crypto from 'crypto';
+import { parseHTML } from 'linkedom';
 
 // Setup the DOM context with any necessary shims/polyfills and ensure the VM
 // context global has everything that a normal document does so Hydrogen can

--- a/server/hydrogen-render/render-hydrogen-to-string.js
+++ b/server/hydrogen-render/render-hydrogen-to-string.js
@@ -56,4 +56,4 @@ async function renderHydrogenToString(renderOptions) {
   }
 }
 
-module.exports = renderHydrogenToString;
+export default renderHydrogenToString;

--- a/server/hydrogen-render/render-hydrogen-to-string.js
+++ b/server/hydrogen-render/render-hydrogen-to-string.js
@@ -4,9 +4,15 @@
 // we receive the SSR results. We don't want Hydrogen to keep running after we
 // get our initial rendered HTML.
 
+import { createRequire } from 'node:module';
 import assert from 'assert';
 import RethrownError from '../lib/rethrown-error.js';
 import runInChildProcess from '../child-process-runner/run-in-child-process.js';
+
+const require = createRequire(import.meta.url);
+const renderHydrogenToStringUnsafeModulePath = require.resolve(
+  './render-hydrogen-to-string-unsafe'
+);
 
 // The render should be fast. If it's taking more than 5 seconds, something has
 // gone really wrong.
@@ -38,7 +44,7 @@ async function renderHydrogenToString(renderOptions) {
     // we receive the SSR results. We don't want Hydrogen to keep running after we
     // get our initial rendered HTML.
     const hydrogenHtmlOutput = await runInChildProcess(
-      require.resolve('./render-hydrogen-to-string-unsafe'),
+      renderHydrogenToStringUnsafeModulePath,
       renderOptions,
       {
         timeout: RENDER_TIMEOUT,

--- a/server/hydrogen-render/render-hydrogen-to-string.js
+++ b/server/hydrogen-render/render-hydrogen-to-string.js
@@ -4,14 +4,13 @@
 // we receive the SSR results. We don't want Hydrogen to keep running after we
 // get our initial rendered HTML.
 
-import { createRequire } from 'node:module';
 import assert from 'assert';
 import RethrownError from '../lib/rethrown-error.js';
 import runInChildProcess from '../child-process-runner/run-in-child-process.js';
 
-const require = createRequire(import.meta.url);
-const renderHydrogenToStringUnsafeModulePath = require.resolve(
-  './render-hydrogen-to-string-unsafe'
+const renderHydrogenToStringUnsafeModulePath = new URL(
+  './render-hydrogen-to-string-unsafe.js',
+  import.meta.url
 );
 
 // The render should be fast. If it's taking more than 5 seconds, something has

--- a/server/hydrogen-render/render-hydrogen-to-string.js
+++ b/server/hydrogen-render/render-hydrogen-to-string.js
@@ -4,9 +4,9 @@
 // we receive the SSR results. We don't want Hydrogen to keep running after we
 // get our initial rendered HTML.
 
-const assert = require('assert');
-const RethrownError = require('../lib/rethrown-error');
-const runInChildProcess = require('../child-process-runner/run-in-child-process');
+import assert from 'assert';
+import RethrownError from '../lib/rethrown-error';
+import runInChildProcess from '../child-process-runner/run-in-child-process';
 
 // The render should be fast. If it's taking more than 5 seconds, something has
 // gone really wrong.
@@ -30,7 +30,7 @@ async function renderHydrogenToString(renderOptions) {
     // the `child_process` part of it by using
     // `render-hydrogen-to-string-unsafe` directly.
     // ```js
-    // const _renderHydrogenToStringUnsafe = require('../hydrogen-render/render-hydrogen-to-string-unsafe');
+    // import _renderHydrogenToStringUnsafe from '../hydrogen-render/render-hydrogen-to-string-unsafe';
     // const hydrogenHtmlOutput = await _renderHydrogenToStringUnsafe(renderOptions);
     // ```
     //

--- a/server/hydrogen-render/render-hydrogen-to-string.js
+++ b/server/hydrogen-render/render-hydrogen-to-string.js
@@ -1,5 +1,3 @@
-'use strict';
-
 // Server-side render Hydrogen to a string.
 //
 // We use a `child_process` because we want to be able to exit the process after

--- a/server/hydrogen-render/render-hydrogen-to-string.js
+++ b/server/hydrogen-render/render-hydrogen-to-string.js
@@ -5,8 +5,8 @@
 // get our initial rendered HTML.
 
 import assert from 'assert';
-import RethrownError from '../lib/rethrown-error';
-import runInChildProcess from '../child-process-runner/run-in-child-process';
+import RethrownError from '../lib/rethrown-error.js';
+import runInChildProcess from '../child-process-runner/run-in-child-process.js';
 
 // The render should be fast. If it's taking more than 5 seconds, something has
 // gone really wrong.
@@ -30,7 +30,7 @@ async function renderHydrogenToString(renderOptions) {
     // the `child_process` part of it by using
     // `render-hydrogen-to-string-unsafe` directly.
     // ```js
-    // import _renderHydrogenToStringUnsafe from '../hydrogen-render/render-hydrogen-to-string-unsafe';
+    // import _renderHydrogenToStringUnsafe from '../hydrogen-render/render-hydrogen-to-string-unsafe.js';
     // const hydrogenHtmlOutput = await _renderHydrogenToStringUnsafe(renderOptions);
     // ```
     //

--- a/server/hydrogen-render/render-hydrogen-vm-render-script-to-page-html.js
+++ b/server/hydrogen-render/render-hydrogen-vm-render-script-to-page-html.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const assert = require('assert');
 
 const { getSerializableSpans } = require('../tracing/tracing-middleware');

--- a/server/hydrogen-render/render-hydrogen-vm-render-script-to-page-html.js
+++ b/server/hydrogen-render/render-hydrogen-vm-render-script-to-page-html.js
@@ -1,9 +1,9 @@
-const assert = require('assert');
+import assert from 'assert';
 
-const { getSerializableSpans } = require('../tracing/tracing-middleware');
-const renderHydrogenToString = require('../hydrogen-render/render-hydrogen-to-string');
-const sanitizeHtml = require('../lib/sanitize-html');
-const safeJson = require('../lib/safe-json');
+import { getSerializableSpans } from '../tracing/tracing-middleware';
+import renderHydrogenToString from '../hydrogen-render/render-hydrogen-to-string';
+import sanitizeHtml from '../lib/sanitize-html';
+import safeJson from '../lib/safe-json';
 
 async function renderHydrogenVmRenderScriptToPageHtml({
   pageOptions,

--- a/server/hydrogen-render/render-hydrogen-vm-render-script-to-page-html.js
+++ b/server/hydrogen-render/render-hydrogen-vm-render-script-to-page-html.js
@@ -101,4 +101,4 @@ if (atEventId) {
   return pageHtml;
 }
 
-module.exports = renderHydrogenVmRenderScriptToPageHtml;
+export default renderHydrogenVmRenderScriptToPageHtml;

--- a/server/hydrogen-render/render-hydrogen-vm-render-script-to-page-html.js
+++ b/server/hydrogen-render/render-hydrogen-vm-render-script-to-page-html.js
@@ -1,9 +1,9 @@
 import assert from 'assert';
 
-import { getSerializableSpans } from '../tracing/tracing-middleware';
-import renderHydrogenToString from '../hydrogen-render/render-hydrogen-to-string';
-import sanitizeHtml from '../lib/sanitize-html';
-import safeJson from '../lib/safe-json';
+import { getSerializableSpans } from '../tracing/tracing-middleware.js';
+import renderHydrogenToString from '../hydrogen-render/render-hydrogen-to-string.js';
+import sanitizeHtml from '../lib/sanitize-html.js';
+import safeJson from '../lib/safe-json.js';
 
 async function renderHydrogenVmRenderScriptToPageHtml({
   pageOptions,

--- a/server/lib/config.js
+++ b/server/lib/config.js
@@ -55,4 +55,4 @@ nconf.add('defaults', {
   format: JSON5,
 });
 
-module.exports = nconf;
+export default nconf;

--- a/server/lib/config.js
+++ b/server/lib/config.js
@@ -1,5 +1,3 @@
-'use strict';
-
 // This file is based off the Gitter config,
 // https://gitlab.com/gitlab-org/gitter/env/blob/master/lib/config.js
 

--- a/server/lib/config.js
+++ b/server/lib/config.js
@@ -1,6 +1,7 @@
 // This file is based off the Gitter config,
 // https://gitlab.com/gitlab-org/gitter/env/blob/master/lib/config.js
 
+import { fileURLToPath } from 'node:url';
 import path from 'path';
 import nconf from 'nconf';
 import JSON5 from 'json5';
@@ -21,6 +22,7 @@ function configureNodeEnv() {
 
 const nodeEnv = configureNodeEnv();
 console.log(`Config is using nodeEnv=${nodeEnv}`);
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const configDir = path.join(__dirname, '../../config');
 
 // Setup nconf to use (in-order):

--- a/server/lib/config.js
+++ b/server/lib/config.js
@@ -1,9 +1,9 @@
 // This file is based off the Gitter config,
 // https://gitlab.com/gitlab-org/gitter/env/blob/master/lib/config.js
 
-const path = require('path');
-const nconf = require('nconf');
-const JSON5 = require('json5');
+import path from 'path';
+import nconf from 'nconf';
+import JSON5 from 'json5';
 
 function configureNodeEnv() {
   const nodeEnv = process.env.NODE_ENV;

--- a/server/lib/express-async-handler.js
+++ b/server/lib/express-async-handler.js
@@ -9,4 +9,4 @@ const asyncUtil = (fn) =>
     return Promise.resolve(fnReturn).catch(next);
   };
 
-module.exports = asyncUtil;
+export default asyncUtil;

--- a/server/lib/express-async-handler.js
+++ b/server/lib/express-async-handler.js
@@ -1,5 +1,3 @@
-'use strict';
-
 // Simple middleware for handling exceptions inside of async express routes and
 // passing them to your express error handlers.
 //

--- a/server/lib/fetch-endpoint.js
+++ b/server/lib/fetch-endpoint.js
@@ -63,9 +63,4 @@ async function fetchEndpointAsJson(endpoint, options) {
   return { data, res };
 }
 
-module.exports = {
-  HTTPResponseError,
-  fetchEndpoint,
-  fetchEndpointAsText,
-  fetchEndpointAsJson,
-};
+export { HTTPResponseError, fetchEndpoint, fetchEndpointAsText, fetchEndpointAsJson };

--- a/server/lib/fetch-endpoint.js
+++ b/server/lib/fetch-endpoint.js
@@ -1,4 +1,4 @@
-const fetch = require('node-fetch');
+import fetch from 'node-fetch';
 
 class HTTPResponseError extends Error {
   constructor(response, responseText, ...args) {

--- a/server/lib/fetch-endpoint.js
+++ b/server/lib/fetch-endpoint.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const fetch = require('node-fetch');
 
 class HTTPResponseError extends Error {

--- a/server/lib/get-version-tags.js
+++ b/server/lib/get-version-tags.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const assert = require('assert');
 const path = require('path');
 const fs = require('fs');

--- a/server/lib/get-version-tags.js
+++ b/server/lib/get-version-tags.js
@@ -1,3 +1,4 @@
+import { fileURLToPath } from 'node:url';
 import assert from 'assert';
 import path from 'path';
 import fs from 'fs';
@@ -6,6 +7,8 @@ import packageInfo from '../../package.json';
 assert(packageInfo.version);
 
 const packageVersion = packageInfo.version;
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 function readFileSync(path) {
   try {

--- a/server/lib/get-version-tags.js
+++ b/server/lib/get-version-tags.js
@@ -2,8 +2,9 @@ import { fileURLToPath } from 'node:url';
 import assert from 'assert';
 import path from 'path';
 import fs from 'fs';
+import { readFile } from 'node:fs/promises';
 
-import packageInfo from '../../package.json';
+const packageInfo = JSON.parse(await readFile('package.json'));
 assert(packageInfo.version);
 
 const packageVersion = packageInfo.version;

--- a/server/lib/get-version-tags.js
+++ b/server/lib/get-version-tags.js
@@ -1,8 +1,8 @@
-const assert = require('assert');
-const path = require('path');
-const fs = require('fs');
+import assert from 'assert';
+import path from 'path';
+import fs from 'fs';
 
-const packageInfo = require('../../package.json');
+import packageInfo from '../../package.json';
 assert(packageInfo.version);
 
 const packageVersion = packageInfo.version;

--- a/server/lib/get-version-tags.js
+++ b/server/lib/get-version-tags.js
@@ -29,4 +29,4 @@ function getVersionTags() {
   };
 }
 
-module.exports = getVersionTags;
+export default getVersionTags;

--- a/server/lib/matrix-utils/ensure-room-joined.js
+++ b/server/lib/matrix-utils/ensure-room-joined.js
@@ -1,11 +1,11 @@
-const assert = require('assert');
-const urlJoin = require('url-join');
+import assert from 'assert';
+import urlJoin from 'url-join';
 
-const { fetchEndpointAsJson } = require('../fetch-endpoint');
-const getServerNameFromMatrixRoomIdOrAlias = require('./get-server-name-from-matrix-room-id-or-alias');
+import { fetchEndpointAsJson } from '../fetch-endpoint';
+import getServerNameFromMatrixRoomIdOrAlias from './get-server-name-from-matrix-room-id-or-alias';
 
-const config = require('../config');
-const StatusError = require('../status-error');
+import config from '../config';
+import StatusError from '../status-error';
 const matrixServerUrl = config.get('matrixServerUrl');
 assert(matrixServerUrl);
 

--- a/server/lib/matrix-utils/ensure-room-joined.js
+++ b/server/lib/matrix-utils/ensure-room-joined.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const assert = require('assert');
 const urlJoin = require('url-join');
 

--- a/server/lib/matrix-utils/ensure-room-joined.js
+++ b/server/lib/matrix-utils/ensure-room-joined.js
@@ -47,4 +47,4 @@ async function ensureRoomJoined(accessToken, roomIdOrAlias, viaServers = new Set
   }
 }
 
-module.exports = ensureRoomJoined;
+export default ensureRoomJoined;

--- a/server/lib/matrix-utils/ensure-room-joined.js
+++ b/server/lib/matrix-utils/ensure-room-joined.js
@@ -1,11 +1,11 @@
 import assert from 'assert';
 import urlJoin from 'url-join';
 
-import { fetchEndpointAsJson } from '../fetch-endpoint';
-import getServerNameFromMatrixRoomIdOrAlias from './get-server-name-from-matrix-room-id-or-alias';
+import { fetchEndpointAsJson } from '../fetch-endpoint.js';
+import getServerNameFromMatrixRoomIdOrAlias from './get-server-name-from-matrix-room-id-or-alias.js';
 
-import config from '../config';
-import StatusError from '../status-error';
+import config from '../config.js';
+import StatusError from '../status-error.js';
 const matrixServerUrl = config.get('matrixServerUrl');
 assert(matrixServerUrl);
 

--- a/server/lib/matrix-utils/fetch-events-from-timestamp-backwards.js
+++ b/server/lib/matrix-utils/fetch-events-from-timestamp-backwards.js
@@ -1,11 +1,11 @@
 import assert from 'assert';
-import { traceFunction } from '../../tracing/trace-utilities';
+import { traceFunction } from '../../tracing/trace-utilities.js';
 
-import { DIRECTION } from 'matrix-public-archive-shared/lib/reference-values';
-import timestampToEvent from './timestamp-to-event';
-import getMessagesResponseFromEventId from './get-messages-response-from-event-id';
+import { DIRECTION } from 'matrix-public-archive-shared/lib/reference-values.js';
+import timestampToEvent from './timestamp-to-event.js';
+import getMessagesResponseFromEventId from './get-messages-response-from-event-id.js';
 
-import config from '../config';
+import config from '../config.js';
 const matrixServerUrl = config.get('matrixServerUrl');
 assert(matrixServerUrl);
 

--- a/server/lib/matrix-utils/fetch-events-from-timestamp-backwards.js
+++ b/server/lib/matrix-utils/fetch-events-from-timestamp-backwards.js
@@ -1,11 +1,11 @@
-const assert = require('assert');
-const { traceFunction } = require('../../tracing/trace-utilities');
+import assert from 'assert';
+import { traceFunction } from '../../tracing/trace-utilities';
 
-const { DIRECTION } = require('matrix-public-archive-shared/lib/reference-values');
-const timestampToEvent = require('./timestamp-to-event');
-const getMessagesResponseFromEventId = require('./get-messages-response-from-event-id');
+import { DIRECTION } from 'matrix-public-archive-shared/lib/reference-values';
+import timestampToEvent from './timestamp-to-event';
+import getMessagesResponseFromEventId from './get-messages-response-from-event-id';
 
-const config = require('../config');
+import config from '../config';
 const matrixServerUrl = config.get('matrixServerUrl');
 assert(matrixServerUrl);
 

--- a/server/lib/matrix-utils/fetch-events-from-timestamp-backwards.js
+++ b/server/lib/matrix-utils/fetch-events-from-timestamp-backwards.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const assert = require('assert');
 const { traceFunction } = require('../../tracing/trace-utilities');
 

--- a/server/lib/matrix-utils/fetch-events-from-timestamp-backwards.js
+++ b/server/lib/matrix-utils/fetch-events-from-timestamp-backwards.js
@@ -85,4 +85,4 @@ async function fetchEventsFromTimestampBackwards({ accessToken, roomId, ts, limi
   };
 }
 
-module.exports = traceFunction(fetchEventsFromTimestampBackwards);
+export default traceFunction(fetchEventsFromTimestampBackwards);

--- a/server/lib/matrix-utils/fetch-public-rooms.js
+++ b/server/lib/matrix-utils/fetch-public-rooms.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const assert = require('assert');
 
 const urlJoin = require('url-join');

--- a/server/lib/matrix-utils/fetch-public-rooms.js
+++ b/server/lib/matrix-utils/fetch-public-rooms.js
@@ -1,10 +1,10 @@
 import assert from 'assert';
 
 import urlJoin from 'url-join';
-import { fetchEndpointAsJson } from '../fetch-endpoint';
-import { traceFunction } from '../../tracing/trace-utilities';
+import { fetchEndpointAsJson } from '../fetch-endpoint.js';
+import { traceFunction } from '../../tracing/trace-utilities.js';
 
-import config from '../config';
+import config from '../config.js';
 const matrixServerUrl = config.get('matrixServerUrl');
 assert(matrixServerUrl);
 

--- a/server/lib/matrix-utils/fetch-public-rooms.js
+++ b/server/lib/matrix-utils/fetch-public-rooms.js
@@ -1,10 +1,10 @@
-const assert = require('assert');
+import assert from 'assert';
 
-const urlJoin = require('url-join');
-const { fetchEndpointAsJson } = require('../fetch-endpoint');
-const { traceFunction } = require('../../tracing/trace-utilities');
+import urlJoin from 'url-join';
+import { fetchEndpointAsJson } from '../fetch-endpoint';
+import { traceFunction } from '../../tracing/trace-utilities';
 
-const config = require('../config');
+import config from '../config';
 const matrixServerUrl = config.get('matrixServerUrl');
 assert(matrixServerUrl);
 

--- a/server/lib/matrix-utils/fetch-public-rooms.js
+++ b/server/lib/matrix-utils/fetch-public-rooms.js
@@ -48,4 +48,4 @@ async function fetchPublicRooms(accessToken, { server, searchTerm, paginationTok
   };
 }
 
-module.exports = traceFunction(fetchPublicRooms);
+export default traceFunction(fetchPublicRooms);

--- a/server/lib/matrix-utils/fetch-room-data.js
+++ b/server/lib/matrix-utils/fetch-room-data.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const assert = require('assert');
 
 const urlJoin = require('url-join');

--- a/server/lib/matrix-utils/fetch-room-data.js
+++ b/server/lib/matrix-utils/fetch-room-data.js
@@ -218,7 +218,7 @@ const fetchRoomData = traceFunction(async function (matrixAccessToken, roomId) {
   };
 });
 
-module.exports = {
+export {
   fetchRoomData,
   fetchRoomCreationInfo,
   fetchPredecessorInfo,

--- a/server/lib/matrix-utils/fetch-room-data.js
+++ b/server/lib/matrix-utils/fetch-room-data.js
@@ -1,11 +1,11 @@
-const assert = require('assert');
+import assert from 'assert';
 
-const urlJoin = require('url-join');
-const { fetchEndpointAsJson } = require('../fetch-endpoint');
-const parseViaServersFromUserInput = require('../parse-via-servers-from-user-input');
-const { traceFunction } = require('../../tracing/trace-utilities');
+import urlJoin from 'url-join';
+import { fetchEndpointAsJson } from '../fetch-endpoint';
+import parseViaServersFromUserInput from '../parse-via-servers-from-user-input';
+import { traceFunction } from '../../tracing/trace-utilities';
 
-const config = require('../config');
+import config from '../config';
 const matrixServerUrl = config.get('matrixServerUrl');
 assert(matrixServerUrl);
 

--- a/server/lib/matrix-utils/fetch-room-data.js
+++ b/server/lib/matrix-utils/fetch-room-data.js
@@ -1,11 +1,11 @@
 import assert from 'assert';
 
 import urlJoin from 'url-join';
-import { fetchEndpointAsJson } from '../fetch-endpoint';
-import parseViaServersFromUserInput from '../parse-via-servers-from-user-input';
-import { traceFunction } from '../../tracing/trace-utilities';
+import { fetchEndpointAsJson } from '../fetch-endpoint.js';
+import parseViaServersFromUserInput from '../parse-via-servers-from-user-input.js';
+import { traceFunction } from '../../tracing/trace-utilities.js';
 
-import config from '../config';
+import config from '../config.js';
 const matrixServerUrl = config.get('matrixServerUrl');
 assert(matrixServerUrl);
 

--- a/server/lib/matrix-utils/get-messages-response-from-event-id.js
+++ b/server/lib/matrix-utils/get-messages-response-from-event-id.js
@@ -59,4 +59,4 @@ async function getMessagesResponseFromEventId({ accessToken, roomId, eventId, di
   return messageResData;
 }
 
-module.exports = getMessagesResponseFromEventId;
+export default getMessagesResponseFromEventId;

--- a/server/lib/matrix-utils/get-messages-response-from-event-id.js
+++ b/server/lib/matrix-utils/get-messages-response-from-event-id.js
@@ -1,10 +1,10 @@
 import assert from 'assert';
 import urlJoin from 'url-join';
 
-import { DIRECTION } from 'matrix-public-archive-shared/lib/reference-values';
-import { fetchEndpointAsJson } from '../fetch-endpoint';
+import { DIRECTION } from 'matrix-public-archive-shared/lib/reference-values.js';
+import { fetchEndpointAsJson } from '../fetch-endpoint.js';
 
-import config from '../config';
+import config from '../config.js';
 const matrixServerUrl = config.get('matrixServerUrl');
 assert(matrixServerUrl);
 

--- a/server/lib/matrix-utils/get-messages-response-from-event-id.js
+++ b/server/lib/matrix-utils/get-messages-response-from-event-id.js
@@ -1,10 +1,10 @@
-const assert = require('assert');
-const urlJoin = require('url-join');
+import assert from 'assert';
+import urlJoin from 'url-join';
 
-const { DIRECTION } = require('matrix-public-archive-shared/lib/reference-values');
-const { fetchEndpointAsJson } = require('../fetch-endpoint');
+import { DIRECTION } from 'matrix-public-archive-shared/lib/reference-values';
+import { fetchEndpointAsJson } from '../fetch-endpoint';
 
-const config = require('../config');
+import config from '../config';
 const matrixServerUrl = config.get('matrixServerUrl');
 assert(matrixServerUrl);
 

--- a/server/lib/matrix-utils/get-messages-response-from-event-id.js
+++ b/server/lib/matrix-utils/get-messages-response-from-event-id.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const assert = require('assert');
 const urlJoin = require('url-join');
 

--- a/server/lib/matrix-utils/get-server-name-from-matrix-room-id-or-alias.js
+++ b/server/lib/matrix-utils/get-server-name-from-matrix-room-id-or-alias.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const assert = require('assert');
 
 // See https://spec.matrix.org/v1.5/appendices/#server-name

--- a/server/lib/matrix-utils/get-server-name-from-matrix-room-id-or-alias.js
+++ b/server/lib/matrix-utils/get-server-name-from-matrix-room-id-or-alias.js
@@ -20,4 +20,4 @@ function getServerNameFromMatrixRoomIdOrAlias(roomIdOrAlias) {
   return servername;
 }
 
-module.exports = getServerNameFromMatrixRoomIdOrAlias;
+export default getServerNameFromMatrixRoomIdOrAlias;

--- a/server/lib/matrix-utils/get-server-name-from-matrix-room-id-or-alias.js
+++ b/server/lib/matrix-utils/get-server-name-from-matrix-room-id-or-alias.js
@@ -1,4 +1,4 @@
-const assert = require('assert');
+import assert from 'assert';
 
 // See https://spec.matrix.org/v1.5/appendices/#server-name
 function getServerNameFromMatrixRoomIdOrAlias(roomIdOrAlias) {

--- a/server/lib/matrix-utils/timestamp-to-event.js
+++ b/server/lib/matrix-utils/timestamp-to-event.js
@@ -1,10 +1,10 @@
-const assert = require('assert');
-const urlJoin = require('url-join');
+import assert from 'assert';
+import urlJoin from 'url-join';
 
-const { fetchEndpointAsJson } = require('../fetch-endpoint');
-const { traceFunction } = require('../../tracing/trace-utilities');
+import { fetchEndpointAsJson } from '../fetch-endpoint';
+import { traceFunction } from '../../tracing/trace-utilities';
 
-const config = require('../config');
+import config from '../config';
 const matrixServerUrl = config.get('matrixServerUrl');
 assert(matrixServerUrl);
 

--- a/server/lib/matrix-utils/timestamp-to-event.js
+++ b/server/lib/matrix-utils/timestamp-to-event.js
@@ -1,10 +1,10 @@
 import assert from 'assert';
 import urlJoin from 'url-join';
 
-import { fetchEndpointAsJson } from '../fetch-endpoint';
-import { traceFunction } from '../../tracing/trace-utilities';
+import { fetchEndpointAsJson } from '../fetch-endpoint.js';
+import { traceFunction } from '../../tracing/trace-utilities.js';
 
-import config from '../config';
+import config from '../config.js';
 const matrixServerUrl = config.get('matrixServerUrl');
 assert(matrixServerUrl);
 

--- a/server/lib/matrix-utils/timestamp-to-event.js
+++ b/server/lib/matrix-utils/timestamp-to-event.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const assert = require('assert');
 const urlJoin = require('url-join');
 

--- a/server/lib/matrix-utils/timestamp-to-event.js
+++ b/server/lib/matrix-utils/timestamp-to-event.js
@@ -30,4 +30,4 @@ async function timestampToEvent({ accessToken, roomId, ts, direction }) {
   };
 }
 
-module.exports = traceFunction(timestampToEvent);
+export default traceFunction(timestampToEvent);

--- a/server/lib/parse-via-servers-from-user-input.js
+++ b/server/lib/parse-via-servers-from-user-input.js
@@ -1,4 +1,4 @@
-const StatusError = require('../lib/status-error');
+import StatusError from '../lib/status-error';
 
 function parseViaServersFromUserInput(rawViaServers) {
   // `rawViaServers` could be an array, a single string, or undefined. Turn it into an

--- a/server/lib/parse-via-servers-from-user-input.js
+++ b/server/lib/parse-via-servers-from-user-input.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const StatusError = require('../lib/status-error');
 
 function parseViaServersFromUserInput(rawViaServers) {

--- a/server/lib/parse-via-servers-from-user-input.js
+++ b/server/lib/parse-via-servers-from-user-input.js
@@ -25,4 +25,4 @@ function parseViaServersFromUserInput(rawViaServers) {
   return new Set(viaServerList);
 }
 
-module.exports = parseViaServersFromUserInput;
+export default parseViaServersFromUserInput;

--- a/server/lib/parse-via-servers-from-user-input.js
+++ b/server/lib/parse-via-servers-from-user-input.js
@@ -1,4 +1,4 @@
-import StatusError from '../lib/status-error';
+import StatusError from '../lib/status-error.js';
 
 function parseViaServersFromUserInput(rawViaServers) {
   // `rawViaServers` could be an array, a single string, or undefined. Turn it into an

--- a/server/lib/rethrown-error.js
+++ b/server/lib/rethrown-error.js
@@ -55,4 +55,4 @@ class RethrownError extends ExtendedError {
   }
 }
 
-module.exports = RethrownError;
+export default RethrownError;

--- a/server/lib/rethrown-error.js
+++ b/server/lib/rethrown-error.js
@@ -1,5 +1,3 @@
-'use strict';
-
 // via https://stackoverflow.com/a/42755876/796832
 
 // Standard error extender from @deployable/errors

--- a/server/lib/safe-json.js
+++ b/server/lib/safe-json.js
@@ -1,5 +1,3 @@
-'use strict';
-
 // via https://gitlab.com/gitterHQ/webapp/-/blob/615c78d0b0a314c2c9e4098b8d2ba0471d16961b/modules/templates/lib/safe-json.js
 function safeJson(string) {
   if (!string) return string;

--- a/server/lib/safe-json.js
+++ b/server/lib/safe-json.js
@@ -5,4 +5,4 @@ function safeJson(string) {
   return string.replace(/<\//g, '<\\/');
 }
 
-module.exports = safeJson;
+export default safeJson;

--- a/server/lib/sanitize-html.js
+++ b/server/lib/sanitize-html.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const createDOMPurify = require('dompurify');
 const { parseHTML } = require('linkedom');
 

--- a/server/lib/sanitize-html.js
+++ b/server/lib/sanitize-html.js
@@ -1,5 +1,5 @@
-const createDOMPurify = require('dompurify');
-const { parseHTML } = require('linkedom');
+import createDOMPurify from 'dompurify';
+import { parseHTML } from 'linkedom';
 
 const dom = parseHTML(`
 <!doctype html>

--- a/server/lib/sanitize-html.js
+++ b/server/lib/sanitize-html.js
@@ -16,4 +16,4 @@ function sanitizeHtml(dirtyHtml) {
   return cleanHtml;
 }
 
-module.exports = sanitizeHtml;
+export default sanitizeHtml;

--- a/server/lib/set-headers-to-preload-assets.js
+++ b/server/lib/set-headers-to-preload-assets.js
@@ -1,4 +1,4 @@
-const assert = require('assert');
+import assert from 'assert';
 
 // Set some preload link headers which we can use with Cloudflare to turn into 103 early
 // hints, https://developers.cloudflare.com/cache/about/early-hints/

--- a/server/lib/set-headers-to-preload-assets.js
+++ b/server/lib/set-headers-to-preload-assets.js
@@ -24,4 +24,4 @@ function setHeadersToPreloadAssets(res, pageOptions) {
   res.append('Link', [].concat(styleLinks, scriptLinks).join(', '));
 }
 
-module.exports = setHeadersToPreloadAssets;
+export default setHeadersToPreloadAssets;

--- a/server/lib/set-headers-to-preload-assets.js
+++ b/server/lib/set-headers-to-preload-assets.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const assert = require('assert');
 
 // Set some preload link headers which we can use with Cloudflare to turn into 103 early

--- a/server/lib/status-error.js
+++ b/server/lib/status-error.js
@@ -17,4 +17,4 @@ function StatusError(status, inputMessage) {
 StatusError.prototype = Object.create(Error.prototype);
 StatusError.prototype.constructor = StatusError;
 
-module.exports = StatusError;
+export default StatusError;

--- a/server/lib/status-error.js
+++ b/server/lib/status-error.js
@@ -1,4 +1,4 @@
-var http = require('http');
+import http from 'http';
 
 /* Create an error as per http://bluebirdjs.com/docs/api/catch.html */
 function StatusError(status, inputMessage) {

--- a/server/lib/status-error.js
+++ b/server/lib/status-error.js
@@ -1,5 +1,3 @@
-'use strict';
-
 var http = require('http');
 
 /* Create an error as per http://bluebirdjs.com/docs/api/catch.html */

--- a/server/middleware/content-security-policy-middleware.js
+++ b/server/middleware/content-security-policy-middleware.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const crypto = require('crypto');
 const assert = require('assert');
 

--- a/server/middleware/content-security-policy-middleware.js
+++ b/server/middleware/content-security-policy-middleware.js
@@ -1,7 +1,7 @@
 import crypto from 'crypto';
 import assert from 'assert';
 
-import config from '../lib/config';
+import config from '../lib/config.js';
 const matrixServerUrl = config.get('matrixServerUrl');
 assert(matrixServerUrl);
 

--- a/server/middleware/content-security-policy-middleware.js
+++ b/server/middleware/content-security-policy-middleware.js
@@ -1,7 +1,7 @@
-const crypto = require('crypto');
-const assert = require('assert');
+import crypto from 'crypto';
+import assert from 'assert';
 
-const config = require('../lib/config');
+import config from '../lib/config';
 const matrixServerUrl = config.get('matrixServerUrl');
 assert(matrixServerUrl);
 

--- a/server/middleware/content-security-policy-middleware.js
+++ b/server/middleware/content-security-policy-middleware.js
@@ -46,4 +46,4 @@ function contentSecurityPolicyMiddleware(req, res, next) {
   next();
 }
 
-module.exports = contentSecurityPolicyMiddleware;
+export default contentSecurityPolicyMiddleware;

--- a/server/middleware/identify-route-middleware.js
+++ b/server/middleware/identify-route-middleware.js
@@ -6,4 +6,4 @@ function identifyRouteMiddleware(routeName) {
   };
 }
 
-module.exports = identifyRouteMiddleware;
+export default identifyRouteMiddleware;

--- a/server/middleware/identify-route-middleware.js
+++ b/server/middleware/identify-route-middleware.js
@@ -1,5 +1,3 @@
-'use strict';
-
 // via https://gitlab.com/gitterHQ/env/-/blob/2a184afea5dc5f4db478d651b3597001474ee932/lib/middlewares/identify-route.js
 function identifyRouteMiddleware(routeName) {
   return function identifyRoute(req, res, next) {

--- a/server/middleware/prevent-clickjacking-middleware.js
+++ b/server/middleware/prevent-clickjacking-middleware.js
@@ -5,4 +5,4 @@ function preventClickjackingMiddleware(req, res, next) {
   next();
 }
 
-module.exports = preventClickjackingMiddleware;
+export default preventClickjackingMiddleware;

--- a/server/middleware/prevent-clickjacking-middleware.js
+++ b/server/middleware/prevent-clickjacking-middleware.js
@@ -1,5 +1,3 @@
-'use strict';
-
 // Don't allow others to iframe embed which can lead to clickjacking
 function preventClickjackingMiddleware(req, res, next) {
   res.set('X-Frame-Options', 'DENY');

--- a/server/middleware/redirect-to-correct-archive-url-if-bad-sigil-middleware.js
+++ b/server/middleware/redirect-to-correct-archive-url-if-bad-sigil-middleware.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const assert = require('assert');
 const escapeStringRegexp = require('escape-string-regexp');
 

--- a/server/middleware/redirect-to-correct-archive-url-if-bad-sigil-middleware.js
+++ b/server/middleware/redirect-to-correct-archive-url-if-bad-sigil-middleware.js
@@ -1,7 +1,7 @@
-const assert = require('assert');
-const escapeStringRegexp = require('escape-string-regexp');
+import assert from 'assert';
+import escapeStringRegexp from 'escape-string-regexp';
 
-const config = require('../lib/config');
+import config from '../lib/config';
 const basePath = config.get('basePath');
 assert(basePath);
 const {

--- a/server/middleware/redirect-to-correct-archive-url-if-bad-sigil-middleware.js
+++ b/server/middleware/redirect-to-correct-archive-url-if-bad-sigil-middleware.js
@@ -65,4 +65,4 @@ function redirectToCorrectArchiveUrlIfBadSigilMiddleware(req, res, next) {
   next();
 }
 
-module.exports = redirectToCorrectArchiveUrlIfBadSigilMiddleware;
+export default redirectToCorrectArchiveUrlIfBadSigilMiddleware;

--- a/server/middleware/redirect-to-correct-archive-url-if-bad-sigil-middleware.js
+++ b/server/middleware/redirect-to-correct-archive-url-if-bad-sigil-middleware.js
@@ -4,9 +4,7 @@ import escapeStringRegexp from 'escape-string-regexp';
 import config from '../lib/config';
 const basePath = config.get('basePath');
 assert(basePath);
-const {
-  VALID_SIGIL_TO_ENTITY_DESCRIPTOR_MAP,
-} = require('matrix-public-archive-shared/lib/reference-values');
+import { VALID_SIGIL_TO_ENTITY_DESCRIPTOR_MAP } from 'matrix-public-archive-shared/lib/reference-values';
 
 // Create a regex string that will match a normal string or the URI encoded string or
 // any combination of some characters being URI encoded. Only worries about characters

--- a/server/middleware/redirect-to-correct-archive-url-if-bad-sigil-middleware.js
+++ b/server/middleware/redirect-to-correct-archive-url-if-bad-sigil-middleware.js
@@ -1,10 +1,10 @@
 import assert from 'assert';
 import escapeStringRegexp from 'escape-string-regexp';
 
-import config from '../lib/config';
+import config from '../lib/config.js';
 const basePath = config.get('basePath');
 assert(basePath);
-import { VALID_SIGIL_TO_ENTITY_DESCRIPTOR_MAP } from 'matrix-public-archive-shared/lib/reference-values';
+import { VALID_SIGIL_TO_ENTITY_DESCRIPTOR_MAP } from 'matrix-public-archive-shared/lib/reference-values.js';
 
 // Create a regex string that will match a normal string or the URI encoded string or
 // any combination of some characters being URI encoded. Only worries about characters

--- a/server/middleware/timeout-middleware.js
+++ b/server/middleware/timeout-middleware.js
@@ -1,11 +1,11 @@
-const assert = require('assert');
-const urlJoin = require('url-join');
-const asyncHandler = require('../lib/express-async-handler');
-const { getSerializableSpans, getActiveTraceId } = require('../tracing/tracing-middleware');
-const sanitizeHtml = require('../lib/sanitize-html');
-const safeJson = require('../lib/safe-json');
+import assert from 'assert';
+import urlJoin from 'url-join';
+import asyncHandler from '../lib/express-async-handler';
+import { getSerializableSpans, getActiveTraceId } from '../tracing/tracing-middleware';
+import sanitizeHtml from '../lib/sanitize-html';
+import safeJson from '../lib/safe-json';
 
-const config = require('../lib/config');
+import config from '../lib/config';
 const basePath = config.get('basePath');
 assert(basePath);
 const requestTimeoutMs = config.get('requestTimeoutMs');

--- a/server/middleware/timeout-middleware.js
+++ b/server/middleware/timeout-middleware.js
@@ -96,4 +96,4 @@ async function timeoutMiddleware(req, res, next) {
   next();
 }
 
-module.exports = asyncHandler(timeoutMiddleware);
+export default asyncHandler(timeoutMiddleware);

--- a/server/middleware/timeout-middleware.js
+++ b/server/middleware/timeout-middleware.js
@@ -1,11 +1,11 @@
 import assert from 'assert';
 import urlJoin from 'url-join';
-import asyncHandler from '../lib/express-async-handler';
-import { getSerializableSpans, getActiveTraceId } from '../tracing/tracing-middleware';
-import sanitizeHtml from '../lib/sanitize-html';
-import safeJson from '../lib/safe-json';
+import asyncHandler from '../lib/express-async-handler.js';
+import { getSerializableSpans, getActiveTraceId } from '../tracing/tracing-middleware.js';
+import sanitizeHtml from '../lib/sanitize-html.js';
+import safeJson from '../lib/safe-json.js';
 
-import config from '../lib/config';
+import config from '../lib/config.js';
 const basePath = config.get('basePath');
 assert(basePath);
 const requestTimeoutMs = config.get('requestTimeoutMs');

--- a/server/middleware/timeout-middleware.js
+++ b/server/middleware/timeout-middleware.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const assert = require('assert');
 const urlJoin = require('url-join');
 const asyncHandler = require('../lib/express-async-handler');

--- a/server/routes/client-side-room-alias-hash-redirect-route.js
+++ b/server/routes/client-side-room-alias-hash-redirect-route.js
@@ -1,9 +1,9 @@
-const assert = require('assert');
-const urlJoin = require('url-join');
-const safeJson = require('../lib/safe-json');
-const sanitizeHtml = require('../lib/sanitize-html');
+import assert from 'assert';
+import urlJoin from 'url-join';
+import safeJson from '../lib/safe-json';
+import sanitizeHtml from '../lib/sanitize-html';
 
-const config = require('../lib/config');
+import config from '../lib/config';
 const basePath = config.get('basePath');
 assert(basePath);
 

--- a/server/routes/client-side-room-alias-hash-redirect-route.js
+++ b/server/routes/client-side-room-alias-hash-redirect-route.js
@@ -1,9 +1,9 @@
 import assert from 'assert';
 import urlJoin from 'url-join';
-import safeJson from '../lib/safe-json';
-import sanitizeHtml from '../lib/sanitize-html';
+import safeJson from '../lib/safe-json.js';
+import sanitizeHtml from '../lib/sanitize-html.js';
 
-import config from '../lib/config';
+import config from '../lib/config.js';
 const basePath = config.get('basePath');
 assert(basePath);
 

--- a/server/routes/client-side-room-alias-hash-redirect-route.js
+++ b/server/routes/client-side-room-alias-hash-redirect-route.js
@@ -57,4 +57,4 @@ function clientSideRoomAliasHashRedirectRoute(req, res) {
   res.send(pageHtml);
 }
 
-module.exports = clientSideRoomAliasHashRedirectRoute;
+export default clientSideRoomAliasHashRedirectRoute;

--- a/server/routes/client-side-room-alias-hash-redirect-route.js
+++ b/server/routes/client-side-room-alias-hash-redirect-route.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const assert = require('assert');
 const urlJoin = require('url-join');
 const safeJson = require('../lib/safe-json');

--- a/server/routes/install-routes.js
+++ b/server/routes/install-routes.js
@@ -86,4 +86,4 @@ function installRoutes(app) {
   );
 }
 
-module.exports = installRoutes;
+export default installRoutes;

--- a/server/routes/install-routes.js
+++ b/server/routes/install-routes.js
@@ -1,3 +1,4 @@
+import { fileURLToPath } from 'node:url';
 import path from 'path';
 import express from 'express';
 import cors from 'cors';
@@ -10,6 +11,8 @@ import contentSecurityPolicyMiddleware from '../middleware/content-security-poli
 import identifyRoute from '../middleware/identify-route-middleware';
 import clientSideRoomAliasHashRedirectRoute from './client-side-room-alias-hash-redirect-route';
 import redirectToCorrectArchiveUrlIfBadSigil from '../middleware/redirect-to-correct-archive-url-if-bad-sigil-middleware';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 function installRoutes(app) {
   app.use(handleTracingMiddleware);

--- a/server/routes/install-routes.js
+++ b/server/routes/install-routes.js
@@ -44,16 +44,17 @@ function installRoutes(app) {
     })
   );
 
-  app.use(
-    '/hydrogen-assets',
-    express.static(path.dirname(require.resolve('hydrogen-view-sdk/assets/main.js')))
+  const hydrogenAssetsDirectoryPath = path.dirname(
+    require.resolve('hydrogen-view-sdk/assets/main.js')
   );
+  app.use('/hydrogen-assets', express.static(hydrogenAssetsDirectoryPath));
 
+  const hydrogenStylesPath = require.resolve('hydrogen-view-sdk/assets/theme-element-light.css');
   app.get(
     '/hydrogen-assets/hydrogen-styles.css',
     asyncHandler(async function (req, res) {
       res.set('Content-Type', 'text/css');
-      res.sendFile(require.resolve('hydrogen-view-sdk/assets/theme-element-light.css'));
+      res.sendFile(hydrogenStylesPath);
     })
   );
 

--- a/server/routes/install-routes.js
+++ b/server/routes/install-routes.js
@@ -1,3 +1,4 @@
+import { createRequire } from 'node:module';
 import { fileURLToPath } from 'node:url';
 import path from 'path';
 import express from 'express';
@@ -15,6 +16,7 @@ import redirectToCorrectArchiveUrlIfBadSigil from '../middleware/redirect-to-cor
 import roomDirectoryRoutes from './room-directory-routes.js';
 import roomRoutes from './room-routes.js';
 
+const require = createRequire(import.meta.url);
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 function installRoutes(app) {
@@ -42,24 +44,15 @@ function installRoutes(app) {
     })
   );
 
-  // We have to disable no-missing-require lint because it doesn't take into
-  // account `package.json`. `exports`, see
-  // https://github.com/mysticatea/eslint-plugin-node/issues/255
   app.use(
     '/hydrogen-assets',
-    // eslint-disable-next-line node/no-missing-require
     express.static(path.dirname(require.resolve('hydrogen-view-sdk/assets/main.js')))
   );
 
   app.get(
-    // This has to be at the root so that the font URL references resolve correctly
     '/hydrogen-assets/hydrogen-styles.css',
     asyncHandler(async function (req, res) {
       res.set('Content-Type', 'text/css');
-      // We have to disable no-missing-require lint because it doesn't take into
-      // account `package.json`. `exports`, see
-      // https://github.com/mysticatea/eslint-plugin-node/issues/255
-      // eslint-disable-next-line node/no-missing-require
       res.sendFile(require.resolve('hydrogen-view-sdk/assets/theme-element-light.css'));
     })
   );

--- a/server/routes/install-routes.js
+++ b/server/routes/install-routes.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const path = require('path');
 const express = require('express');
 const cors = require('cors');

--- a/server/routes/install-routes.js
+++ b/server/routes/install-routes.js
@@ -1,15 +1,15 @@
-const path = require('path');
-const express = require('express');
-const cors = require('cors');
-const asyncHandler = require('../lib/express-async-handler');
+import path from 'path';
+import express from 'express';
+import cors from 'cors';
+import asyncHandler from '../lib/express-async-handler';
 
-const { handleTracingMiddleware } = require('../tracing/tracing-middleware');
-const getVersionTags = require('../lib/get-version-tags');
-const preventClickjackingMiddleware = require('../middleware/prevent-clickjacking-middleware');
-const contentSecurityPolicyMiddleware = require('../middleware/content-security-policy-middleware');
-const identifyRoute = require('../middleware/identify-route-middleware');
-const clientSideRoomAliasHashRedirectRoute = require('./client-side-room-alias-hash-redirect-route');
-const redirectToCorrectArchiveUrlIfBadSigil = require('../middleware/redirect-to-correct-archive-url-if-bad-sigil-middleware');
+import { handleTracingMiddleware } from '../tracing/tracing-middleware';
+import getVersionTags from '../lib/get-version-tags';
+import preventClickjackingMiddleware from '../middleware/prevent-clickjacking-middleware';
+import contentSecurityPolicyMiddleware from '../middleware/content-security-policy-middleware';
+import identifyRoute from '../middleware/identify-route-middleware';
+import clientSideRoomAliasHashRedirectRoute from './client-side-room-alias-hash-redirect-route';
+import redirectToCorrectArchiveUrlIfBadSigil from '../middleware/redirect-to-correct-archive-url-if-bad-sigil-middleware';
 
 function installRoutes(app) {
   app.use(handleTracingMiddleware);

--- a/server/routes/install-routes.js
+++ b/server/routes/install-routes.js
@@ -2,18 +2,18 @@ import { fileURLToPath } from 'node:url';
 import path from 'path';
 import express from 'express';
 import cors from 'cors';
-import asyncHandler from '../lib/express-async-handler';
+import asyncHandler from '../lib/express-async-handler.js';
 
-import { handleTracingMiddleware } from '../tracing/tracing-middleware';
-import getVersionTags from '../lib/get-version-tags';
-import preventClickjackingMiddleware from '../middleware/prevent-clickjacking-middleware';
-import contentSecurityPolicyMiddleware from '../middleware/content-security-policy-middleware';
-import identifyRoute from '../middleware/identify-route-middleware';
-import clientSideRoomAliasHashRedirectRoute from './client-side-room-alias-hash-redirect-route';
-import redirectToCorrectArchiveUrlIfBadSigil from '../middleware/redirect-to-correct-archive-url-if-bad-sigil-middleware';
+import { handleTracingMiddleware } from '../tracing/tracing-middleware.js';
+import getVersionTags from '../lib/get-version-tags.js';
+import preventClickjackingMiddleware from '../middleware/prevent-clickjacking-middleware.js';
+import contentSecurityPolicyMiddleware from '../middleware/content-security-policy-middleware.js';
+import identifyRoute from '../middleware/identify-route-middleware.js';
+import clientSideRoomAliasHashRedirectRoute from './client-side-room-alias-hash-redirect-route.js';
+import redirectToCorrectArchiveUrlIfBadSigil from '../middleware/redirect-to-correct-archive-url-if-bad-sigil-middleware.js';
 
-import roomDirectoryRoutes from './room-directory-routes';
-import roomRoutes from './room-routes';
+import roomDirectoryRoutes from './room-directory-routes.js';
+import roomRoutes from './room-routes.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 

--- a/server/routes/install-routes.js
+++ b/server/routes/install-routes.js
@@ -12,6 +12,9 @@ import identifyRoute from '../middleware/identify-route-middleware';
 import clientSideRoomAliasHashRedirectRoute from './client-side-room-alias-hash-redirect-route';
 import redirectToCorrectArchiveUrlIfBadSigil from '../middleware/redirect-to-correct-archive-url-if-bad-sigil-middleware';
 
+import roomDirectoryRoutes from './room-directory-routes';
+import roomRoutes from './room-routes';
+
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 function installRoutes(app) {
@@ -66,10 +69,10 @@ function installRoutes(app) {
   app.use('/img', express.static(path.join(__dirname, '../../public/img')));
   app.use('/js', express.static(path.join(__dirname, '../../dist/')));
 
-  app.use('/', require('./room-directory-routes'));
+  app.use('/', roomDirectoryRoutes);
 
   // For room aliases (/r) or room ID's (/roomid)
-  app.use('/:entityDescriptor(r|roomid)/:roomIdOrAliasDirty', require('./room-routes'));
+  app.use('/:entityDescriptor(r|roomid)/:roomIdOrAliasDirty', roomRoutes);
 
   // Since everything after the hash (`#`) won't make it to the server, let's serve a 404
   // page that will potentially redirect them to the correct place if they tried

--- a/server/routes/room-directory-routes.js
+++ b/server/routes/room-directory-routes.js
@@ -3,14 +3,14 @@ import assert from 'assert';
 import path from 'path';
 import urlJoin from 'url-join';
 import express from 'express';
-import asyncHandler from '../lib/express-async-handler';
+import asyncHandler from '../lib/express-async-handler.js';
 
-import identifyRoute from '../middleware/identify-route-middleware';
-import fetchPublicRooms from '../lib/matrix-utils/fetch-public-rooms';
-import renderHydrogenVmRenderScriptToPageHtml from '../hydrogen-render/render-hydrogen-vm-render-script-to-page-html';
-import setHeadersToPreloadAssets from '../lib/set-headers-to-preload-assets';
+import identifyRoute from '../middleware/identify-route-middleware.js';
+import fetchPublicRooms from '../lib/matrix-utils/fetch-public-rooms.js';
+import renderHydrogenVmRenderScriptToPageHtml from '../hydrogen-render/render-hydrogen-vm-render-script-to-page-html.js';
+import setHeadersToPreloadAssets from '../lib/set-headers-to-preload-assets.js';
 
-import config from '../lib/config';
+import config from '../lib/config.js';
 const basePath = config.get('basePath');
 assert(basePath);
 const matrixServerUrl = config.get('matrixServerUrl');

--- a/server/routes/room-directory-routes.js
+++ b/server/routes/room-directory-routes.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const assert = require('assert');
 const path = require('path');
 const urlJoin = require('url-join');

--- a/server/routes/room-directory-routes.js
+++ b/server/routes/room-directory-routes.js
@@ -111,4 +111,4 @@ router.get(
   })
 );
 
-module.exports = router;
+export default router;

--- a/server/routes/room-directory-routes.js
+++ b/server/routes/room-directory-routes.js
@@ -1,15 +1,15 @@
-const assert = require('assert');
-const path = require('path');
-const urlJoin = require('url-join');
-const express = require('express');
-const asyncHandler = require('../lib/express-async-handler');
+import assert from 'assert';
+import path from 'path';
+import urlJoin from 'url-join';
+import express from 'express';
+import asyncHandler from '../lib/express-async-handler';
 
-const identifyRoute = require('../middleware/identify-route-middleware');
-const fetchPublicRooms = require('../lib/matrix-utils/fetch-public-rooms');
-const renderHydrogenVmRenderScriptToPageHtml = require('../hydrogen-render/render-hydrogen-vm-render-script-to-page-html');
-const setHeadersToPreloadAssets = require('../lib/set-headers-to-preload-assets');
+import identifyRoute from '../middleware/identify-route-middleware';
+import fetchPublicRooms from '../lib/matrix-utils/fetch-public-rooms';
+import renderHydrogenVmRenderScriptToPageHtml from '../hydrogen-render/render-hydrogen-vm-render-script-to-page-html';
+import setHeadersToPreloadAssets from '../lib/set-headers-to-preload-assets';
 
-const config = require('../lib/config');
+import config from '../lib/config';
 const basePath = config.get('basePath');
 assert(basePath);
 const matrixServerUrl = config.get('matrixServerUrl');

--- a/server/routes/room-directory-routes.js
+++ b/server/routes/room-directory-routes.js
@@ -1,3 +1,4 @@
+import { fileURLToPath } from 'node:url';
 import assert from 'assert';
 import path from 'path';
 import urlJoin from 'url-join';
@@ -19,6 +20,8 @@ assert(matrixServerName);
 const matrixAccessToken = config.get('matrixAccessToken');
 assert(matrixAccessToken);
 const stopSearchEngineIndexing = config.get('stopSearchEngineIndexing');
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 const router = express.Router({
   caseSensitive: true,

--- a/server/routes/room-routes.js
+++ b/server/routes/room-routes.js
@@ -912,4 +912,4 @@ router.get(
   })
 );
 
-module.exports = router;
+export default router;

--- a/server/routes/room-routes.js
+++ b/server/routes/room-routes.js
@@ -12,11 +12,11 @@ import identifyRoute from '../middleware/identify-route-middleware';
 
 import { HTTPResponseError } from '../lib/fetch-endpoint';
 import parseViaServersFromUserInput from '../lib/parse-via-servers-from-user-input';
-const {
+import {
   fetchRoomData,
   fetchPredecessorInfo,
   fetchSuccessorInfo,
-} = require('../lib/matrix-utils/fetch-room-data');
+} from '../lib/matrix-utils/fetch-room-data';
 import fetchEventsFromTimestampBackwards from '../lib/matrix-utils/fetch-events-from-timestamp-backwards';
 import ensureRoomJoined from '../lib/matrix-utils/ensure-room-joined';
 import timestampToEvent from '../lib/matrix-utils/timestamp-to-event';
@@ -25,14 +25,14 @@ import getMessagesResponseFromEventId from '../lib/matrix-utils/get-messages-res
 import renderHydrogenVmRenderScriptToPageHtml from '../hydrogen-render/render-hydrogen-vm-render-script-to-page-html';
 import setHeadersToPreloadAssets from '../lib/set-headers-to-preload-assets';
 import MatrixPublicArchiveURLCreator from 'matrix-public-archive-shared/lib/url-creator';
-const {
+import {
   MS_LOOKUP,
   TIME_PRECISION_VALUES,
   DIRECTION,
   VALID_ENTITY_DESCRIPTOR_TO_SIGIL_MAP,
-} = require('matrix-public-archive-shared/lib/reference-values');
+} from 'matrix-public-archive-shared/lib/reference-values';
 const { ONE_DAY_IN_MS, ONE_HOUR_IN_MS, ONE_MINUTE_IN_MS, ONE_SECOND_IN_MS } = MS_LOOKUP;
-const {
+import {
   roundUpTimestampToUtcDay,
   roundUpTimestampToUtcHour,
   roundUpTimestampToUtcMinute,
@@ -45,7 +45,7 @@ const {
   areTimestampsFromSameUtcHour,
   areTimestampsFromSameUtcMinute,
   areTimestampsFromSameUtcSecond,
-} = require('matrix-public-archive-shared/lib/timestamp-utilities');
+} from 'matrix-public-archive-shared/lib/timestamp-utilities';
 
 import config from '../lib/config';
 const basePath = config.get('basePath');

--- a/server/routes/room-routes.js
+++ b/server/routes/room-routes.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const assert = require('assert');
 const path = require('path');
 const urlJoin = require('url-join');

--- a/server/routes/room-routes.js
+++ b/server/routes/room-routes.js
@@ -1,4 +1,5 @@
 import assert from 'assert';
+import { fileURLToPath } from 'node:url';
 import path from 'path';
 import urlJoin from 'url-join';
 import express from 'express';
@@ -54,6 +55,8 @@ assert(matrixServerUrl);
 const matrixAccessToken = config.get('matrixAccessToken');
 assert(matrixAccessToken);
 const stopSearchEngineIndexing = config.get('stopSearchEngineIndexing');
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 const matrixPublicArchiveURLCreator = new MatrixPublicArchiveURLCreator(basePath);
 

--- a/server/routes/room-routes.js
+++ b/server/routes/room-routes.js
@@ -1,29 +1,29 @@
-const assert = require('assert');
-const path = require('path');
-const urlJoin = require('url-join');
-const express = require('express');
-const asyncHandler = require('../lib/express-async-handler');
-const StatusError = require('../lib/status-error');
+import assert from 'assert';
+import path from 'path';
+import urlJoin from 'url-join';
+import express from 'express';
+import asyncHandler from '../lib/express-async-handler';
+import StatusError from '../lib/status-error';
 
-const timeoutMiddleware = require('../middleware/timeout-middleware');
-const redirectToCorrectArchiveUrlIfBadSigil = require('../middleware/redirect-to-correct-archive-url-if-bad-sigil-middleware');
-const identifyRoute = require('../middleware/identify-route-middleware');
+import timeoutMiddleware from '../middleware/timeout-middleware';
+import redirectToCorrectArchiveUrlIfBadSigil from '../middleware/redirect-to-correct-archive-url-if-bad-sigil-middleware';
+import identifyRoute from '../middleware/identify-route-middleware';
 
-const { HTTPResponseError } = require('../lib/fetch-endpoint');
-const parseViaServersFromUserInput = require('../lib/parse-via-servers-from-user-input');
+import { HTTPResponseError } from '../lib/fetch-endpoint';
+import parseViaServersFromUserInput from '../lib/parse-via-servers-from-user-input';
 const {
   fetchRoomData,
   fetchPredecessorInfo,
   fetchSuccessorInfo,
 } = require('../lib/matrix-utils/fetch-room-data');
-const fetchEventsFromTimestampBackwards = require('../lib/matrix-utils/fetch-events-from-timestamp-backwards');
-const ensureRoomJoined = require('../lib/matrix-utils/ensure-room-joined');
-const timestampToEvent = require('../lib/matrix-utils/timestamp-to-event');
-const { removeMe_fetchRoomCreateEventId } = require('../lib/matrix-utils/fetch-room-data');
-const getMessagesResponseFromEventId = require('../lib/matrix-utils/get-messages-response-from-event-id');
-const renderHydrogenVmRenderScriptToPageHtml = require('../hydrogen-render/render-hydrogen-vm-render-script-to-page-html');
-const setHeadersToPreloadAssets = require('../lib/set-headers-to-preload-assets');
-const MatrixPublicArchiveURLCreator = require('matrix-public-archive-shared/lib/url-creator');
+import fetchEventsFromTimestampBackwards from '../lib/matrix-utils/fetch-events-from-timestamp-backwards';
+import ensureRoomJoined from '../lib/matrix-utils/ensure-room-joined';
+import timestampToEvent from '../lib/matrix-utils/timestamp-to-event';
+import { removeMe_fetchRoomCreateEventId } from '../lib/matrix-utils/fetch-room-data';
+import getMessagesResponseFromEventId from '../lib/matrix-utils/get-messages-response-from-event-id';
+import renderHydrogenVmRenderScriptToPageHtml from '../hydrogen-render/render-hydrogen-vm-render-script-to-page-html';
+import setHeadersToPreloadAssets from '../lib/set-headers-to-preload-assets';
+import MatrixPublicArchiveURLCreator from 'matrix-public-archive-shared/lib/url-creator';
 const {
   MS_LOOKUP,
   TIME_PRECISION_VALUES,
@@ -46,7 +46,7 @@ const {
   areTimestampsFromSameUtcSecond,
 } = require('matrix-public-archive-shared/lib/timestamp-utilities');
 
-const config = require('../lib/config');
+import config from '../lib/config';
 const basePath = config.get('basePath');
 assert(basePath);
 const matrixServerUrl = config.get('matrixServerUrl');

--- a/server/routes/room-routes.js
+++ b/server/routes/room-routes.js
@@ -3,34 +3,34 @@ import { fileURLToPath } from 'node:url';
 import path from 'path';
 import urlJoin from 'url-join';
 import express from 'express';
-import asyncHandler from '../lib/express-async-handler';
-import StatusError from '../lib/status-error';
+import asyncHandler from '../lib/express-async-handler.js';
+import StatusError from '../lib/status-error.js';
 
-import timeoutMiddleware from '../middleware/timeout-middleware';
-import redirectToCorrectArchiveUrlIfBadSigil from '../middleware/redirect-to-correct-archive-url-if-bad-sigil-middleware';
-import identifyRoute from '../middleware/identify-route-middleware';
+import timeoutMiddleware from '../middleware/timeout-middleware.js';
+import redirectToCorrectArchiveUrlIfBadSigil from '../middleware/redirect-to-correct-archive-url-if-bad-sigil-middleware.js';
+import identifyRoute from '../middleware/identify-route-middleware.js';
 
-import { HTTPResponseError } from '../lib/fetch-endpoint';
-import parseViaServersFromUserInput from '../lib/parse-via-servers-from-user-input';
+import { HTTPResponseError } from '../lib/fetch-endpoint.js';
+import parseViaServersFromUserInput from '../lib/parse-via-servers-from-user-input.js';
 import {
   fetchRoomData,
   fetchPredecessorInfo,
   fetchSuccessorInfo,
-} from '../lib/matrix-utils/fetch-room-data';
-import fetchEventsFromTimestampBackwards from '../lib/matrix-utils/fetch-events-from-timestamp-backwards';
-import ensureRoomJoined from '../lib/matrix-utils/ensure-room-joined';
-import timestampToEvent from '../lib/matrix-utils/timestamp-to-event';
-import { removeMe_fetchRoomCreateEventId } from '../lib/matrix-utils/fetch-room-data';
-import getMessagesResponseFromEventId from '../lib/matrix-utils/get-messages-response-from-event-id';
-import renderHydrogenVmRenderScriptToPageHtml from '../hydrogen-render/render-hydrogen-vm-render-script-to-page-html';
-import setHeadersToPreloadAssets from '../lib/set-headers-to-preload-assets';
-import MatrixPublicArchiveURLCreator from 'matrix-public-archive-shared/lib/url-creator';
+} from '../lib/matrix-utils/fetch-room-data.js';
+import fetchEventsFromTimestampBackwards from '../lib/matrix-utils/fetch-events-from-timestamp-backwards.js';
+import ensureRoomJoined from '../lib/matrix-utils/ensure-room-joined.js';
+import timestampToEvent from '../lib/matrix-utils/timestamp-to-event.js';
+import { removeMe_fetchRoomCreateEventId } from '../lib/matrix-utils/fetch-room-data.js';
+import getMessagesResponseFromEventId from '../lib/matrix-utils/get-messages-response-from-event-id.js';
+import renderHydrogenVmRenderScriptToPageHtml from '../hydrogen-render/render-hydrogen-vm-render-script-to-page-html.js';
+import setHeadersToPreloadAssets from '../lib/set-headers-to-preload-assets.js';
+import MatrixPublicArchiveURLCreator from 'matrix-public-archive-shared/lib/url-creator.js';
 import {
   MS_LOOKUP,
   TIME_PRECISION_VALUES,
   DIRECTION,
   VALID_ENTITY_DESCRIPTOR_TO_SIGIL_MAP,
-} from 'matrix-public-archive-shared/lib/reference-values';
+} from 'matrix-public-archive-shared/lib/reference-values.js';
 const { ONE_DAY_IN_MS, ONE_HOUR_IN_MS, ONE_MINUTE_IN_MS, ONE_SECOND_IN_MS } = MS_LOOKUP;
 import {
   roundUpTimestampToUtcDay,
@@ -45,9 +45,9 @@ import {
   areTimestampsFromSameUtcHour,
   areTimestampsFromSameUtcMinute,
   areTimestampsFromSameUtcSecond,
-} from 'matrix-public-archive-shared/lib/timestamp-utilities';
+} from 'matrix-public-archive-shared/lib/timestamp-utilities.js';
 
-import config from '../lib/config';
+import config from '../lib/config.js';
 const basePath = config.get('basePath');
 assert(basePath);
 const matrixServerUrl = config.get('matrixServerUrl');

--- a/server/server.js
+++ b/server/server.js
@@ -1,20 +1,20 @@
 console.log('server process.env.NODE_ENV', process.env.NODE_ENV);
 
-const assert = require('assert');
-const config = require('./lib/config');
+import assert from 'assert';
+import config from './lib/config';
 const basePort = config.get('basePort');
 assert(basePort);
 const tracing = config.get('tracing');
 
 if (tracing) {
   console.log('Tracing is active 🕵️');
-  const { startTracing } = require('./tracing/tracing.js');
+  import { startTracing } from './tracing/tracing.js';
   startTracing();
 }
 
-const express = require('express');
+import express from 'express';
 
-const installRoutes = require('./routes/install-routes');
+import installRoutes from './routes/install-routes';
 
 const app = express();
 installRoutes(app);

--- a/server/server.js
+++ b/server/server.js
@@ -1,7 +1,7 @@
 console.log('server process.env.NODE_ENV', process.env.NODE_ENV);
 
 import assert from 'assert';
-import config from './lib/config';
+import config from './lib/config.js';
 const basePort = config.get('basePort');
 assert(basePort);
 const tracing = config.get('tracing');
@@ -14,7 +14,7 @@ if (tracing) {
 
 import express from 'express';
 
-import installRoutes from './routes/install-routes';
+import installRoutes from './routes/install-routes.js';
 
 const app = express();
 installRoutes(app);

--- a/server/server.js
+++ b/server/server.js
@@ -1,5 +1,3 @@
-'use strict';
-
 console.log('server process.env.NODE_ENV', process.env.NODE_ENV);
 
 const assert = require('assert');

--- a/server/server.js
+++ b/server/server.js
@@ -8,7 +8,7 @@ const tracing = config.get('tracing');
 
 if (tracing) {
   console.log('Tracing is active 🕵️');
-  import { startTracing } from './tracing/tracing.js';
+  const { startTracing } = await import('./tracing/tracing.js');
   startTracing();
 }
 

--- a/server/server.js
+++ b/server/server.js
@@ -21,4 +21,4 @@ installRoutes(app);
 
 const server = app.listen(basePort);
 
-module.exports = server;
+export default server;

--- a/server/start-dev.js
+++ b/server/start-dev.js
@@ -1,5 +1,3 @@
-'use strict';
-
 console.log('start-dev process.env.NODE_ENV', process.env.NODE_ENV);
 
 const path = require('path');

--- a/server/start-dev.js
+++ b/server/start-dev.js
@@ -1,9 +1,9 @@
 console.log('start-dev process.env.NODE_ENV', process.env.NODE_ENV);
 
-const path = require('path');
-const nodemon = require('nodemon');
+import path from 'path';
+import nodemon from 'nodemon';
 
-const buildClient = require('../build-scripts/build-client');
+import buildClient from '../build-scripts/build-client';
 
 // Build the client-side JavaScript bundle when we see any changes
 buildClient({

--- a/server/start-dev.js
+++ b/server/start-dev.js
@@ -2,10 +2,13 @@
 
 console.log('start-dev process.env.NODE_ENV', process.env.NODE_ENV);
 
+import { fileURLToPath } from 'node:url';
 import path from 'path';
 import nodemon from 'nodemon';
 
 import buildClient from '../build-scripts/build-client';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 // Build the client-side JavaScript bundle when we see any changes
 buildClient({

--- a/server/start-dev.js
+++ b/server/start-dev.js
@@ -1,3 +1,5 @@
+/* eslint-disable node/no-unpublished-import */
+
 console.log('start-dev process.env.NODE_ENV', process.env.NODE_ENV);
 
 import path from 'path';

--- a/server/start-dev.js
+++ b/server/start-dev.js
@@ -19,6 +19,17 @@ buildClient({
   },
 });
 
+const nodeArgs = [
+  // This is necessary for `new vm.SourceTextModule(code[, options])` to be available
+  '--experimental-vm-modules',
+];
+if (process.argv.inspectNode) {
+  nodeArgs.push('--inspect');
+}
+if (process.argv.traceWarningsNode) {
+  nodeArgs.push('--trace-warnings');
+}
+
 // Pass through some args
 const args = [];
 if (process.argv.includes('--tracing')) {
@@ -39,6 +50,7 @@ nodemon({
   ignoreRoot: ['.git'],
   ignore: [path.join(__dirname, '../dist/*')],
   args,
+  nodeArgs,
 });
 
 nodemon

--- a/server/start-dev.js
+++ b/server/start-dev.js
@@ -25,6 +25,10 @@ if (process.argv.includes('--tracing')) {
   args.push('--tracing');
 }
 
+if (process.argv.includes('--logOutputFromChildProcesses')) {
+  args.push('--logOutputFromChildProcesses');
+}
+
 // Listen for any changes to files and restart the Node.js server process
 //
 // For API docs, see

--- a/server/start-dev.js
+++ b/server/start-dev.js
@@ -6,7 +6,7 @@ import { fileURLToPath } from 'node:url';
 import path from 'path';
 import nodemon from 'nodemon';
 
-import buildClient from '../build-scripts/build-client';
+import buildClient from '../build-scripts/build-client.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 

--- a/server/start-dev.js
+++ b/server/start-dev.js
@@ -1,4 +1,4 @@
-/* eslint-disable node/no-unpublished-import */
+/* eslint-disable n/no-unpublished-import */
 
 console.log('start-dev process.env.NODE_ENV', process.env.NODE_ENV);
 

--- a/server/tracing/capture-span-processor.js
+++ b/server/tracing/capture-span-processor.js
@@ -66,4 +66,4 @@ class CaptureSpanProcessor {
   }
 }
 
-module.exports = CaptureSpanProcessor;
+export default CaptureSpanProcessor;

--- a/server/tracing/capture-span-processor.js
+++ b/server/tracing/capture-span-processor.js
@@ -1,6 +1,6 @@
-//const { SpanProcessor } = require('@opentelemetry/sdk-trace-base');
-const { suppressTracing } = require('@opentelemetry/core');
-const { context } = require('@opentelemetry/api');
+//import { SpanProcessor } from '@opentelemetry/sdk-trace-base';
+import { suppressTracing } from '@opentelemetry/core';
+import { context } from '@opentelemetry/api';
 
 // 1. Keeps track of all spans for a given trace after calling
 //    `trackSpansInTrace(traceId)` (call this in a middleware before any other

--- a/server/tracing/capture-span-processor.js
+++ b/server/tracing/capture-span-processor.js
@@ -1,5 +1,3 @@
-'use strict';
-
 //const { SpanProcessor } = require('@opentelemetry/sdk-trace-base');
 const { suppressTracing } = require('@opentelemetry/core');
 const { context } = require('@opentelemetry/api');

--- a/server/tracing/serialize-span.js
+++ b/server/tracing/serialize-span.js
@@ -39,4 +39,4 @@ function serializeSpan(span) {
   };
 }
 
-module.exports = serializeSpan;
+export default serializeSpan;

--- a/server/tracing/serialize-span.js
+++ b/server/tracing/serialize-span.js
@@ -1,7 +1,7 @@
-const {
+import {
   hrTimeToMilliseconds,
   //hrTimeToMicroseconds
-} = require('@opentelemetry/core');
+} from '@opentelemetry/core';
 
 const SAFE_ATTRIBUTES = ['http.method', 'http.url', 'http.status_code', 'http.target'];
 

--- a/server/tracing/serialize-span.js
+++ b/server/tracing/serialize-span.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const {
   hrTimeToMilliseconds,
   //hrTimeToMicroseconds

--- a/server/tracing/trace-utilities.js
+++ b/server/tracing/trace-utilities.js
@@ -1,7 +1,7 @@
-const assert = require('assert');
-const opentelemetryApi = require('@opentelemetry/api');
+import assert from 'assert';
+import opentelemetryApi from '@opentelemetry/api';
 
-const packageInfo = require('../../package.json');
+import packageInfo from '../../package.json';
 assert(packageInfo.name);
 assert(packageInfo.version);
 

--- a/server/tracing/trace-utilities.js
+++ b/server/tracing/trace-utilities.js
@@ -54,7 +54,4 @@ function traceFunction(fn) {
   return trace(fn.name, fn);
 }
 
-module.exports = {
-  trace,
-  traceFunction,
-};
+export { trace, traceFunction };

--- a/server/tracing/trace-utilities.js
+++ b/server/tracing/trace-utilities.js
@@ -1,7 +1,8 @@
 import assert from 'assert';
+import { readFile } from 'node:fs/promises';
 import opentelemetryApi from '@opentelemetry/api';
 
-import packageInfo from '../../package.json';
+const packageInfo = JSON.parse(await readFile('package.json'));
 assert(packageInfo.name);
 assert(packageInfo.version);
 

--- a/server/tracing/trace-utilities.js
+++ b/server/tracing/trace-utilities.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const assert = require('assert');
 const opentelemetryApi = require('@opentelemetry/api');
 

--- a/server/tracing/tracing-middleware.js
+++ b/server/tracing/tracing-middleware.js
@@ -63,7 +63,7 @@ function getSerializableSpans() {
   return [];
 }
 
-module.exports = {
+export {
   handleTracingMiddleware: asyncHandler(handleTracingMiddleware),
   getSerializableSpans,
   getActiveTraceId,

--- a/server/tracing/tracing-middleware.js
+++ b/server/tracing/tracing-middleware.js
@@ -1,8 +1,8 @@
-const opentelemetryApi = require('@opentelemetry/api');
+import opentelemetryApi from '@opentelemetry/api';
 
-const asyncHandler = require('../lib/express-async-handler');
-const { captureSpanProcessor } = require('./tracing');
-const serializeSpan = require('./serialize-span');
+import asyncHandler from '../lib/express-async-handler';
+import { captureSpanProcessor } from './tracing';
+import serializeSpan from './serialize-span';
 
 // From the current active context, grab the `traceId`. The `traceId` will be
 // shared for the whole request because all spans live under the root span.

--- a/server/tracing/tracing-middleware.js
+++ b/server/tracing/tracing-middleware.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const opentelemetryApi = require('@opentelemetry/api');
 
 const asyncHandler = require('../lib/express-async-handler');

--- a/server/tracing/tracing-middleware.js
+++ b/server/tracing/tracing-middleware.js
@@ -1,8 +1,8 @@
 import opentelemetryApi from '@opentelemetry/api';
 
-import asyncHandler from '../lib/express-async-handler';
-import { captureSpanProcessor } from './tracing';
-import serializeSpan from './serialize-span';
+import asyncHandler from '../lib/express-async-handler.js';
+import { captureSpanProcessor } from './tracing.js';
+import serializeSpan from './serialize-span.js';
 
 // From the current active context, grab the `traceId`. The `traceId` will be
 // shared for the whole request because all spans live under the root span.
@@ -21,7 +21,7 @@ function getActiveTraceId() {
 
 // Handles keeping track of tracing spans for each request.
 // Also adds the traceId to the to the `X-Trace-Id` response header.
-async function handleTracingMiddleware(req, res, next) {
+const handleTracingMiddleware = asyncHandler(async function (req, res, next) {
   const traceId = getActiveTraceId();
   if (traceId) {
     // Add the OpenTelemetry trace ID to the `X-Trace-Id` response header so
@@ -39,7 +39,7 @@ async function handleTracingMiddleware(req, res, next) {
   }
 
   next();
-}
+});
 
 // Get all of spans we're willing to show to the user.
 //
@@ -63,8 +63,4 @@ function getSerializableSpans() {
   return [];
 }
 
-export {
-  handleTracingMiddleware: asyncHandler(handleTracingMiddleware),
-  getSerializableSpans,
-  getActiveTraceId,
-};
+export { handleTracingMiddleware, getSerializableSpans, getActiveTraceId };

--- a/server/tracing/tracing.js
+++ b/server/tracing/tracing.js
@@ -14,9 +14,9 @@ import { OTTracePropagator } from '@opentelemetry/propagator-ot-trace';
 import { Resource } from '@opentelemetry/resources';
 import { SemanticResourceAttributes } from '@opentelemetry/semantic-conventions';
 
-import CaptureSpanProcessor from './capture-span-processor';
+import CaptureSpanProcessor from './capture-span-processor.js';
 
-import config from '../lib/config';
+import config from '../lib/config.js';
 const basePath = config.get('basePath');
 assert(basePath);
 const jaegerTracesEndpoint = config.get('jaegerTracesEndpoint');

--- a/server/tracing/tracing.js
+++ b/server/tracing/tracing.js
@@ -1,27 +1,27 @@
-const assert = require('assert');
-const { registerInstrumentations } = require('@opentelemetry/instrumentation');
-const { getNodeAutoInstrumentations } = require('@opentelemetry/auto-instrumentations-node');
-const { diag, DiagConsoleLogger, DiagLogLevel } = require('@opentelemetry/api');
-const { JaegerExporter } = require('@opentelemetry/exporter-jaeger');
+import assert from 'assert';
+import { registerInstrumentations } from '@opentelemetry/instrumentation';
+import { getNodeAutoInstrumentations } from '@opentelemetry/auto-instrumentations-node';
+import { diag, DiagConsoleLogger, DiagLogLevel } from '@opentelemetry/api';
+import { JaegerExporter } from '@opentelemetry/exporter-jaeger';
 const {
   BasicTracerProvider,
   // ConsoleSpanExporter,
   // SimpleSpanProcessor,
   BatchSpanProcessor,
 } = require('@opentelemetry/sdk-trace-base');
-const { AsyncLocalStorageContextManager } = require('@opentelemetry/context-async-hooks');
-const { OTTracePropagator } = require('@opentelemetry/propagator-ot-trace');
-const { Resource } = require('@opentelemetry/resources');
-const { SemanticResourceAttributes } = require('@opentelemetry/semantic-conventions');
+import { AsyncLocalStorageContextManager } from '@opentelemetry/context-async-hooks';
+import { OTTracePropagator } from '@opentelemetry/propagator-ot-trace';
+import { Resource } from '@opentelemetry/resources';
+import { SemanticResourceAttributes } from '@opentelemetry/semantic-conventions';
 
-const CaptureSpanProcessor = require('./capture-span-processor');
+import CaptureSpanProcessor from './capture-span-processor';
 
-const config = require('../lib/config');
+import config from '../lib/config';
 const basePath = config.get('basePath');
 assert(basePath);
 const jaegerTracesEndpoint = config.get('jaegerTracesEndpoint');
 
-const packageInfo = require('../../package.json');
+import packageInfo from '../../package.json';
 assert(packageInfo.name);
 
 const basePathUrl = new URL(basePath);

--- a/server/tracing/tracing.js
+++ b/server/tracing/tracing.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const assert = require('assert');
 const { registerInstrumentations } = require('@opentelemetry/instrumentation');
 const { getNodeAutoInstrumentations } = require('@opentelemetry/auto-instrumentations-node');

--- a/server/tracing/tracing.js
+++ b/server/tracing/tracing.js
@@ -102,8 +102,4 @@ function startTracing() {
   });
 }
 
-module.exports = {
-  startTracing,
-  provider,
-  captureSpanProcessor,
-};
+export { startTracing, provider, captureSpanProcessor };

--- a/server/tracing/tracing.js
+++ b/server/tracing/tracing.js
@@ -3,12 +3,12 @@ import { registerInstrumentations } from '@opentelemetry/instrumentation';
 import { getNodeAutoInstrumentations } from '@opentelemetry/auto-instrumentations-node';
 import { diag, DiagConsoleLogger, DiagLogLevel } from '@opentelemetry/api';
 import { JaegerExporter } from '@opentelemetry/exporter-jaeger';
-const {
+import {
   BasicTracerProvider,
   // ConsoleSpanExporter,
   // SimpleSpanProcessor,
   BatchSpanProcessor,
-} = require('@opentelemetry/sdk-trace-base');
+} from '@opentelemetry/sdk-trace-base';
 import { AsyncLocalStorageContextManager } from '@opentelemetry/context-async-hooks';
 import { OTTracePropagator } from '@opentelemetry/propagator-ot-trace';
 import { Resource } from '@opentelemetry/resources';

--- a/server/tracing/tracing.js
+++ b/server/tracing/tracing.js
@@ -1,4 +1,5 @@
 import assert from 'assert';
+import { readFile } from 'node:fs/promises';
 import { registerInstrumentations } from '@opentelemetry/instrumentation';
 import { getNodeAutoInstrumentations } from '@opentelemetry/auto-instrumentations-node';
 import { diag, DiagConsoleLogger, DiagLogLevel } from '@opentelemetry/api';
@@ -21,7 +22,7 @@ const basePath = config.get('basePath');
 assert(basePath);
 const jaegerTracesEndpoint = config.get('jaegerTracesEndpoint');
 
-import packageInfo from '../../package.json';
+const packageInfo = JSON.parse(await readFile('package.json'));
 assert(packageInfo.name);
 
 const basePathUrl = new URL(basePath);

--- a/shared/hydrogen-vm-render-script.js
+++ b/shared/hydrogen-vm-render-script.js
@@ -1,5 +1,3 @@
-'use strict';
-
 // Isomorphic script that runs in the browser and on the server for SSR (needs
 // browser context) that renders Hydrogen to the `document.body`.
 //

--- a/shared/hydrogen-vm-render-script.js
+++ b/shared/hydrogen-vm-render-script.js
@@ -3,15 +3,15 @@
 //
 // Data is passed in via `window.matrixPublicArchiveContext`
 
-const assert = require('matrix-public-archive-shared/lib/assert');
-const { Platform, MediaRepository, createNavigation, createRouter } = require('hydrogen-view-sdk');
+import assert from 'matrix-public-archive-shared/lib/assert';
+import { Platform, MediaRepository, createNavigation, createRouter } from 'hydrogen-view-sdk';
 
-const { TIME_PRECISION_VALUES } = require('matrix-public-archive-shared/lib/reference-values');
-const ArchiveRoomView = require('matrix-public-archive-shared/views/ArchiveRoomView');
-const ArchiveHistory = require('matrix-public-archive-shared/lib/archive-history');
-const supressBlankAnchorsReloadingThePage = require('matrix-public-archive-shared/lib/supress-blank-anchors-reloading-the-page');
-const ArchiveRoomViewModel = require('matrix-public-archive-shared/viewmodels/ArchiveRoomViewModel');
-const stubPowerLevelsObservable = require('matrix-public-archive-shared/lib/stub-powerlevels-observable');
+import { TIME_PRECISION_VALUES } from 'matrix-public-archive-shared/lib/reference-values';
+import ArchiveRoomView from 'matrix-public-archive-shared/views/ArchiveRoomView';
+import ArchiveHistory from 'matrix-public-archive-shared/lib/archive-history';
+import supressBlankAnchorsReloadingThePage from 'matrix-public-archive-shared/lib/supress-blank-anchors-reloading-the-page';
+import ArchiveRoomViewModel from 'matrix-public-archive-shared/viewmodels/ArchiveRoomViewModel';
+import stubPowerLevelsObservable from 'matrix-public-archive-shared/lib/stub-powerlevels-observable';
 
 const toTimestamp = window.matrixPublicArchiveContext.toTimestamp;
 assert(toTimestamp);

--- a/shared/hydrogen-vm-render-script.js
+++ b/shared/hydrogen-vm-render-script.js
@@ -3,15 +3,15 @@
 //
 // Data is passed in via `window.matrixPublicArchiveContext`
 
-import assert from 'matrix-public-archive-shared/lib/assert';
+import assert from 'matrix-public-archive-shared/lib/assert.js';
 import { Platform, MediaRepository, createNavigation, createRouter } from 'hydrogen-view-sdk';
 
-import { TIME_PRECISION_VALUES } from 'matrix-public-archive-shared/lib/reference-values';
-import ArchiveRoomView from 'matrix-public-archive-shared/views/ArchiveRoomView';
-import ArchiveHistory from 'matrix-public-archive-shared/lib/archive-history';
-import supressBlankAnchorsReloadingThePage from 'matrix-public-archive-shared/lib/supress-blank-anchors-reloading-the-page';
-import ArchiveRoomViewModel from 'matrix-public-archive-shared/viewmodels/ArchiveRoomViewModel';
-import stubPowerLevelsObservable from 'matrix-public-archive-shared/lib/stub-powerlevels-observable';
+import { TIME_PRECISION_VALUES } from 'matrix-public-archive-shared/lib/reference-values.js';
+import ArchiveRoomView from 'matrix-public-archive-shared/views/ArchiveRoomView.js';
+import ArchiveHistory from 'matrix-public-archive-shared/lib/archive-history.js';
+import supressBlankAnchorsReloadingThePage from 'matrix-public-archive-shared/lib/supress-blank-anchors-reloading-the-page.js';
+import ArchiveRoomViewModel from 'matrix-public-archive-shared/viewmodels/ArchiveRoomViewModel.js';
+import stubPowerLevelsObservable from 'matrix-public-archive-shared/lib/stub-powerlevels-observable.js';
 
 const toTimestamp = window.matrixPublicArchiveContext.toTimestamp;
 assert(toTimestamp);

--- a/shared/lib/archive-history.js
+++ b/shared/lib/archive-history.js
@@ -92,4 +92,4 @@ class ArchiveHistory extends History {
   }
 }
 
-module.exports = ArchiveHistory;
+export default ArchiveHistory;

--- a/shared/lib/archive-history.js
+++ b/shared/lib/archive-history.js
@@ -1,5 +1,5 @@
 import { History } from 'hydrogen-view-sdk';
-import assert from './assert';
+import assert from './assert.js';
 
 // Mock a full hash whenever someone asks via `history.get()` but when
 // constructing URL's for use `href` etc, they should relative to the room

--- a/shared/lib/archive-history.js
+++ b/shared/lib/archive-history.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const { History } = require('hydrogen-view-sdk');
 const assert = require('./assert');
 

--- a/shared/lib/archive-history.js
+++ b/shared/lib/archive-history.js
@@ -1,5 +1,5 @@
-const { History } = require('hydrogen-view-sdk');
-const assert = require('./assert');
+import { History } from 'hydrogen-view-sdk';
+import assert from './assert';
 
 // Mock a full hash whenever someone asks via `history.get()` but when
 // constructing URL's for use `href` etc, they should relative to the room

--- a/shared/lib/assert.js
+++ b/shared/lib/assert.js
@@ -1,5 +1,3 @@
-'use strict';
-
 class AssertionError extends Error {
   constructor(...params) {
     // Pass remaining arguments (including vendor specific ones) to parent constructor

--- a/shared/lib/assert.js
+++ b/shared/lib/assert.js
@@ -20,4 +20,4 @@ function assert(value, message) {
   }
 }
 
-module.exports = assert;
+export default assert;

--- a/shared/lib/custom-tile-utilities.js
+++ b/shared/lib/custom-tile-utilities.js
@@ -1,11 +1,11 @@
 // Extending the Hydrogen utilities to add our custom tiles
 
-const { tileClassForEntry, viewClassForTile } = require('hydrogen-view-sdk');
+import { tileClassForEntry, viewClassForTile } from 'hydrogen-view-sdk';
 
-const JumpToPreviousActivitySummaryTileViewModel = require('matrix-public-archive-shared/viewmodels/JumpToPreviousActivitySummaryTileViewModel');
-const JumpToPreviousActivitySummaryTileView = require('matrix-public-archive-shared/views/JumpToPreviousActivitySummaryTileView');
-const JumpToNextActivitySummaryTileViewModel = require('matrix-public-archive-shared/viewmodels/JumpToNextActivitySummaryTileViewModel');
-const JumpToNextActivitySummaryTileView = require('matrix-public-archive-shared/views/JumpToNextActivitySummaryTileView');
+import JumpToPreviousActivitySummaryTileViewModel from 'matrix-public-archive-shared/viewmodels/JumpToPreviousActivitySummaryTileViewModel';
+import JumpToPreviousActivitySummaryTileView from 'matrix-public-archive-shared/views/JumpToPreviousActivitySummaryTileView';
+import JumpToNextActivitySummaryTileViewModel from 'matrix-public-archive-shared/viewmodels/JumpToNextActivitySummaryTileViewModel';
+import JumpToNextActivitySummaryTileView from 'matrix-public-archive-shared/views/JumpToNextActivitySummaryTileView';
 
 function customTileClassForEntry(entry) {
   switch (entry.eventType) {

--- a/shared/lib/custom-tile-utilities.js
+++ b/shared/lib/custom-tile-utilities.js
@@ -29,7 +29,4 @@ function customViewClassForTile(vm) {
   }
 }
 
-module.exports = {
-  customTileClassForEntry,
-  customViewClassForTile,
-};
+export { customTileClassForEntry, customViewClassForTile };

--- a/shared/lib/custom-tile-utilities.js
+++ b/shared/lib/custom-tile-utilities.js
@@ -1,5 +1,3 @@
-'use strict';
-
 // Extending the Hydrogen utilities to add our custom tiles
 
 const { tileClassForEntry, viewClassForTile } = require('hydrogen-view-sdk');

--- a/shared/lib/custom-tile-utilities.js
+++ b/shared/lib/custom-tile-utilities.js
@@ -2,10 +2,10 @@
 
 import { tileClassForEntry, viewClassForTile } from 'hydrogen-view-sdk';
 
-import JumpToPreviousActivitySummaryTileViewModel from 'matrix-public-archive-shared/viewmodels/JumpToPreviousActivitySummaryTileViewModel';
-import JumpToPreviousActivitySummaryTileView from 'matrix-public-archive-shared/views/JumpToPreviousActivitySummaryTileView';
-import JumpToNextActivitySummaryTileViewModel from 'matrix-public-archive-shared/viewmodels/JumpToNextActivitySummaryTileViewModel';
-import JumpToNextActivitySummaryTileView from 'matrix-public-archive-shared/views/JumpToNextActivitySummaryTileView';
+import JumpToPreviousActivitySummaryTileViewModel from 'matrix-public-archive-shared/viewmodels/JumpToPreviousActivitySummaryTileViewModel.js';
+import JumpToPreviousActivitySummaryTileView from 'matrix-public-archive-shared/views/JumpToPreviousActivitySummaryTileView.js';
+import JumpToNextActivitySummaryTileViewModel from 'matrix-public-archive-shared/viewmodels/JumpToNextActivitySummaryTileViewModel.js';
+import JumpToNextActivitySummaryTileView from 'matrix-public-archive-shared/views/JumpToNextActivitySummaryTileView.js';
 
 function customTileClassForEntry(entry) {
   switch (entry.eventType) {

--- a/shared/lib/mxc-url-to-http.js
+++ b/shared/lib/mxc-url-to-http.js
@@ -1,4 +1,4 @@
-const assert = require('./assert');
+import assert from './assert';
 
 // Based off of https://github.com/matrix-org/matrix-bifrost/blob/c7161dd998c4fe968dba4d5da668dc914248f260/src/MessageFormatter.ts#L45-L60
 function mxcUrlToHttp({ mxcUrl, homeserverUrl }) {

--- a/shared/lib/mxc-url-to-http.js
+++ b/shared/lib/mxc-url-to-http.js
@@ -27,4 +27,4 @@ function mxcUrlToHttpThumbnail({ mxcUrl, homeserverUrl, size }) {
   )}?${qs.toString()}`;
 }
 
-module.exports = { mxcUrlToHttp, mxcUrlToHttpThumbnail };
+export { mxcUrlToHttp, mxcUrlToHttpThumbnail };

--- a/shared/lib/mxc-url-to-http.js
+++ b/shared/lib/mxc-url-to-http.js
@@ -1,4 +1,4 @@
-import assert from './assert';
+import assert from './assert.js';
 
 // Based off of https://github.com/matrix-org/matrix-bifrost/blob/c7161dd998c4fe968dba4d5da668dc914248f260/src/MessageFormatter.ts#L45-L60
 function mxcUrlToHttp({ mxcUrl, homeserverUrl }) {

--- a/shared/lib/mxc-url-to-http.js
+++ b/shared/lib/mxc-url-to-http.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const assert = require('./assert');
 
 // Based off of https://github.com/matrix-org/matrix-bifrost/blob/c7161dd998c4fe968dba4d5da668dc914248f260/src/MessageFormatter.ts#L45-L60

--- a/shared/lib/redirect-if-room-alias-in-hash.js
+++ b/shared/lib/redirect-if-room-alias-in-hash.js
@@ -1,5 +1,3 @@
-'use strict';
-
 // https://spec.matrix.org/v1.1/appendices/#room-aliases
 // - `#room_alias:domain`
 // - `#room-alias:server/date/2022/10/27`

--- a/shared/lib/redirect-if-room-alias-in-hash.js
+++ b/shared/lib/redirect-if-room-alias-in-hash.js
@@ -40,4 +40,4 @@ function redirectIfRoomAliasInHash(matrixPublicArchiveURLCreator, redirectCallba
   return false;
 }
 
-module.exports = redirectIfRoomAliasInHash;
+export default redirectIfRoomAliasInHash;

--- a/shared/lib/reference-values.js
+++ b/shared/lib/reference-values.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const MS_LOOKUP = {
   ONE_DAY_IN_MS: 24 * 60 * 60 * 1000,
   ONE_HOUR_IN_MS: 60 * 60 * 1000,

--- a/shared/lib/reference-values.js
+++ b/shared/lib/reference-values.js
@@ -31,7 +31,7 @@ const VALID_ENTITY_DESCRIPTOR_TO_SIGIL_MAP = {
   roomid: '!',
 };
 
-module.exports = {
+export {
   MS_LOOKUP,
   TIME_PRECISION_VALUES,
   DIRECTION,

--- a/shared/lib/stub-powerlevels-observable.js
+++ b/shared/lib/stub-powerlevels-observable.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const { RetainedObservableValue, PowerLevels } = require('hydrogen-view-sdk');
 
 // Fake power levels for viewing the room anonymously

--- a/shared/lib/stub-powerlevels-observable.js
+++ b/shared/lib/stub-powerlevels-observable.js
@@ -1,4 +1,4 @@
-const { RetainedObservableValue, PowerLevels } = require('hydrogen-view-sdk');
+import { RetainedObservableValue, PowerLevels } from 'hydrogen-view-sdk';
 
 // Fake power levels for viewing the room anonymously
 const stubPowerLevels = new PowerLevels({

--- a/shared/lib/stub-powerlevels-observable.js
+++ b/shared/lib/stub-powerlevels-observable.js
@@ -12,4 +12,4 @@ const stubPowerLevelsObservable = new RetainedObservableValue(stubPowerLevels, (
   // I don't think we need to do anything here 🤷
 });
 
-module.exports = stubPowerLevelsObservable;
+export default stubPowerLevelsObservable;

--- a/shared/lib/supress-blank-anchors-reloading-the-page.js
+++ b/shared/lib/supress-blank-anchors-reloading-the-page.js
@@ -1,5 +1,3 @@
-'use strict';
-
 // For any `<a href="">` (anchor with a blank href), instead of reloading the
 // page just remove the hash. Also cleanup whenever the hash changes for
 // whatever reason.

--- a/shared/lib/supress-blank-anchors-reloading-the-page.js
+++ b/shared/lib/supress-blank-anchors-reloading-the-page.js
@@ -45,4 +45,4 @@ function supressBlankAnchorsReloadingThePage() {
   window.addEventListener('hashchange', eventHandler);
 }
 
-module.exports = supressBlankAnchorsReloadingThePage;
+export default supressBlankAnchorsReloadingThePage;

--- a/shared/lib/timestamp-utilities.js
+++ b/shared/lib/timestamp-utilities.js
@@ -1,5 +1,5 @@
-const assert = require('matrix-public-archive-shared/lib/assert');
-const { MS_LOOKUP } = require('matrix-public-archive-shared/lib/reference-values');
+import assert from 'matrix-public-archive-shared/lib/assert';
+import { MS_LOOKUP } from 'matrix-public-archive-shared/lib/reference-values';
 const { ONE_DAY_IN_MS, ONE_HOUR_IN_MS, ONE_MINUTE_IN_MS, ONE_SECOND_IN_MS } = MS_LOOKUP;
 
 function roundUpTimestampToUtcDay(ts) {

--- a/shared/lib/timestamp-utilities.js
+++ b/shared/lib/timestamp-utilities.js
@@ -1,5 +1,5 @@
-import assert from 'matrix-public-archive-shared/lib/assert';
-import { MS_LOOKUP } from 'matrix-public-archive-shared/lib/reference-values';
+import assert from 'matrix-public-archive-shared/lib/assert.js';
+import { MS_LOOKUP } from 'matrix-public-archive-shared/lib/reference-values.js';
 const { ONE_DAY_IN_MS, ONE_HOUR_IN_MS, ONE_MINUTE_IN_MS, ONE_SECOND_IN_MS } = MS_LOOKUP;
 
 function roundUpTimestampToUtcDay(ts) {

--- a/shared/lib/timestamp-utilities.js
+++ b/shared/lib/timestamp-utilities.js
@@ -84,7 +84,7 @@ function areTimestampsFromSameUtcSecond(aTs, bTs) {
   return getUtcStartOfSecondTs(aTs) === getUtcStartOfSecondTs(bTs);
 }
 
-module.exports = {
+export {
   roundUpTimestampToUtcDay,
   roundUpTimestampToUtcHour,
   roundUpTimestampToUtcMinute,

--- a/shared/lib/timestamp-utilities.js
+++ b/shared/lib/timestamp-utilities.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const assert = require('matrix-public-archive-shared/lib/assert');
 const { MS_LOOKUP } = require('matrix-public-archive-shared/lib/reference-values');
 const { ONE_DAY_IN_MS, ONE_HOUR_IN_MS, ONE_MINUTE_IN_MS, ONE_SECOND_IN_MS } = MS_LOOKUP;

--- a/shared/lib/url-creator.js
+++ b/shared/lib/url-creator.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const urlJoin = require('url-join');
 
 const assert = require('matrix-public-archive-shared/lib/assert');

--- a/shared/lib/url-creator.js
+++ b/shared/lib/url-creator.js
@@ -1,7 +1,7 @@
-const urlJoin = require('url-join');
+import urlJoin from 'url-join';
 
-const assert = require('matrix-public-archive-shared/lib/assert');
-const { TIME_PRECISION_VALUES } = require('matrix-public-archive-shared/lib/reference-values');
+import assert from 'matrix-public-archive-shared/lib/assert';
+import { TIME_PRECISION_VALUES } from 'matrix-public-archive-shared/lib/reference-values';
 
 function qsToUrlPiece(qs) {
   if (qs.toString()) {

--- a/shared/lib/url-creator.js
+++ b/shared/lib/url-creator.js
@@ -157,4 +157,4 @@ class URLCreator {
   }
 }
 
-module.exports = URLCreator;
+export default URLCreator;

--- a/shared/lib/url-creator.js
+++ b/shared/lib/url-creator.js
@@ -1,7 +1,7 @@
 import urlJoin from 'url-join';
 
-import assert from 'matrix-public-archive-shared/lib/assert';
-import { TIME_PRECISION_VALUES } from 'matrix-public-archive-shared/lib/reference-values';
+import assert from 'matrix-public-archive-shared/lib/assert.js';
+import { TIME_PRECISION_VALUES } from 'matrix-public-archive-shared/lib/reference-values.js';
 
 function qsToUrlPiece(qs) {
   if (qs.toString()) {

--- a/shared/room-directory-vm-render-script.js
+++ b/shared/room-directory-vm-render-script.js
@@ -3,16 +3,16 @@
 //
 // Data is passed in via `window.matrixPublicArchiveContext`
 
-import assert from 'matrix-public-archive-shared/lib/assert';
+import assert from 'matrix-public-archive-shared/lib/assert.js';
 import { Platform, Navigation, createRouter } from 'hydrogen-view-sdk';
 
-import MatrixPublicArchiveURLCreator from 'matrix-public-archive-shared/lib/url-creator';
-import ArchiveHistory from 'matrix-public-archive-shared/lib/archive-history';
-import supressBlankAnchorsReloadingThePage from 'matrix-public-archive-shared/lib/supress-blank-anchors-reloading-the-page';
-import redirectIfRoomAliasInHash from 'matrix-public-archive-shared/lib/redirect-if-room-alias-in-hash';
+import MatrixPublicArchiveURLCreator from 'matrix-public-archive-shared/lib/url-creator.js';
+import ArchiveHistory from 'matrix-public-archive-shared/lib/archive-history.js';
+import supressBlankAnchorsReloadingThePage from 'matrix-public-archive-shared/lib/supress-blank-anchors-reloading-the-page.js';
+import redirectIfRoomAliasInHash from 'matrix-public-archive-shared/lib/redirect-if-room-alias-in-hash.js';
 
-import RoomDirectoryView from 'matrix-public-archive-shared/views/RoomDirectoryView';
-import RoomDirectoryViewModel from 'matrix-public-archive-shared/viewmodels/RoomDirectoryViewModel';
+import RoomDirectoryView from 'matrix-public-archive-shared/views/RoomDirectoryView.js';
+import RoomDirectoryViewModel from 'matrix-public-archive-shared/viewmodels/RoomDirectoryViewModel.js';
 
 const rooms = window.matrixPublicArchiveContext.rooms;
 assert(rooms);

--- a/shared/room-directory-vm-render-script.js
+++ b/shared/room-directory-vm-render-script.js
@@ -3,16 +3,16 @@
 //
 // Data is passed in via `window.matrixPublicArchiveContext`
 
-const assert = require('matrix-public-archive-shared/lib/assert');
-const { Platform, Navigation, createRouter } = require('hydrogen-view-sdk');
+import assert from 'matrix-public-archive-shared/lib/assert';
+import { Platform, Navigation, createRouter } from 'hydrogen-view-sdk';
 
-const MatrixPublicArchiveURLCreator = require('matrix-public-archive-shared/lib/url-creator');
-const ArchiveHistory = require('matrix-public-archive-shared/lib/archive-history');
-const supressBlankAnchorsReloadingThePage = require('matrix-public-archive-shared/lib/supress-blank-anchors-reloading-the-page');
-const redirectIfRoomAliasInHash = require('matrix-public-archive-shared/lib/redirect-if-room-alias-in-hash');
+import MatrixPublicArchiveURLCreator from 'matrix-public-archive-shared/lib/url-creator';
+import ArchiveHistory from 'matrix-public-archive-shared/lib/archive-history';
+import supressBlankAnchorsReloadingThePage from 'matrix-public-archive-shared/lib/supress-blank-anchors-reloading-the-page';
+import redirectIfRoomAliasInHash from 'matrix-public-archive-shared/lib/redirect-if-room-alias-in-hash';
 
-const RoomDirectoryView = require('matrix-public-archive-shared/views/RoomDirectoryView');
-const RoomDirectoryViewModel = require('matrix-public-archive-shared/viewmodels/RoomDirectoryViewModel');
+import RoomDirectoryView from 'matrix-public-archive-shared/views/RoomDirectoryView';
+import RoomDirectoryViewModel from 'matrix-public-archive-shared/viewmodels/RoomDirectoryViewModel';
 
 const rooms = window.matrixPublicArchiveContext.rooms;
 assert(rooms);

--- a/shared/room-directory-vm-render-script.js
+++ b/shared/room-directory-vm-render-script.js
@@ -1,5 +1,3 @@
-'use strict';
-
 // Isomorphic script that runs in the browser and on the server for SSR (needs
 // browser context) that renders Hydrogen to the `document.body`.
 //

--- a/shared/viewmodels/ArchiveRoomViewModel.js
+++ b/shared/viewmodels/ArchiveRoomViewModel.js
@@ -1,4 +1,4 @@
-const {
+import {
   ViewModel,
   setupLightboxNavigation,
   TilesCollection,
@@ -7,7 +7,7 @@ const {
   EventEntry,
   encodeKey,
   encodeEventIdKey,
-} = require('hydrogen-view-sdk');
+} from 'hydrogen-view-sdk';
 
 import assert from 'matrix-public-archive-shared/lib/assert';
 
@@ -18,14 +18,10 @@ import TimeSelectorViewModel from 'matrix-public-archive-shared/viewmodels/TimeS
 import DeveloperOptionsContentViewModel from 'matrix-public-archive-shared/viewmodels/DeveloperOptionsContentViewModel';
 import RightPanelContentView from 'matrix-public-archive-shared/views/RightPanelContentView';
 import AvatarViewModel from 'matrix-public-archive-shared/viewmodels/AvatarViewModel';
-const {
-  customTileClassForEntry,
-} = require('matrix-public-archive-shared/lib/custom-tile-utilities');
+import { customTileClassForEntry } from 'matrix-public-archive-shared/lib/custom-tile-utilities';
 import stubPowerLevelsObservable from 'matrix-public-archive-shared/lib/stub-powerlevels-observable';
 import { TIME_PRECISION_VALUES } from 'matrix-public-archive-shared/lib/reference-values';
-const {
-  areTimestampsFromSameUtcDay,
-} = require('matrix-public-archive-shared/lib/timestamp-utilities');
+import { areTimestampsFromSameUtcDay } from 'matrix-public-archive-shared/lib/timestamp-utilities';
 
 let txnCount = 0;
 function getFakeEventId() {

--- a/shared/viewmodels/ArchiveRoomViewModel.js
+++ b/shared/viewmodels/ArchiveRoomViewModel.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const {
   ViewModel,
   setupLightboxNavigation,

--- a/shared/viewmodels/ArchiveRoomViewModel.js
+++ b/shared/viewmodels/ArchiveRoomViewModel.js
@@ -9,20 +9,20 @@ const {
   encodeEventIdKey,
 } = require('hydrogen-view-sdk');
 
-const assert = require('matrix-public-archive-shared/lib/assert');
+import assert from 'matrix-public-archive-shared/lib/assert';
 
-const ModalViewModel = require('matrix-public-archive-shared/viewmodels/ModalViewModel');
-const MatrixPublicArchiveURLCreator = require('matrix-public-archive-shared/lib/url-creator');
-const CalendarViewModel = require('matrix-public-archive-shared/viewmodels/CalendarViewModel');
-const TimeSelectorViewModel = require('matrix-public-archive-shared/viewmodels/TimeSelectorViewModel');
-const DeveloperOptionsContentViewModel = require('matrix-public-archive-shared/viewmodels/DeveloperOptionsContentViewModel');
-const RightPanelContentView = require('matrix-public-archive-shared/views/RightPanelContentView');
-const AvatarViewModel = require('matrix-public-archive-shared/viewmodels/AvatarViewModel');
+import ModalViewModel from 'matrix-public-archive-shared/viewmodels/ModalViewModel';
+import MatrixPublicArchiveURLCreator from 'matrix-public-archive-shared/lib/url-creator';
+import CalendarViewModel from 'matrix-public-archive-shared/viewmodels/CalendarViewModel';
+import TimeSelectorViewModel from 'matrix-public-archive-shared/viewmodels/TimeSelectorViewModel';
+import DeveloperOptionsContentViewModel from 'matrix-public-archive-shared/viewmodels/DeveloperOptionsContentViewModel';
+import RightPanelContentView from 'matrix-public-archive-shared/views/RightPanelContentView';
+import AvatarViewModel from 'matrix-public-archive-shared/viewmodels/AvatarViewModel';
 const {
   customTileClassForEntry,
 } = require('matrix-public-archive-shared/lib/custom-tile-utilities');
-const stubPowerLevelsObservable = require('matrix-public-archive-shared/lib/stub-powerlevels-observable');
-const { TIME_PRECISION_VALUES } = require('matrix-public-archive-shared/lib/reference-values');
+import stubPowerLevelsObservable from 'matrix-public-archive-shared/lib/stub-powerlevels-observable';
+import { TIME_PRECISION_VALUES } from 'matrix-public-archive-shared/lib/reference-values';
 const {
   areTimestampsFromSameUtcDay,
 } = require('matrix-public-archive-shared/lib/timestamp-utilities');

--- a/shared/viewmodels/ArchiveRoomViewModel.js
+++ b/shared/viewmodels/ArchiveRoomViewModel.js
@@ -504,4 +504,4 @@ class ArchiveRoomViewModel extends ViewModel {
   }
 }
 
-module.exports = ArchiveRoomViewModel;
+export default ArchiveRoomViewModel;

--- a/shared/viewmodels/ArchiveRoomViewModel.js
+++ b/shared/viewmodels/ArchiveRoomViewModel.js
@@ -9,19 +9,19 @@ import {
   encodeEventIdKey,
 } from 'hydrogen-view-sdk';
 
-import assert from 'matrix-public-archive-shared/lib/assert';
+import assert from 'matrix-public-archive-shared/lib/assert.js';
 
-import ModalViewModel from 'matrix-public-archive-shared/viewmodels/ModalViewModel';
-import MatrixPublicArchiveURLCreator from 'matrix-public-archive-shared/lib/url-creator';
-import CalendarViewModel from 'matrix-public-archive-shared/viewmodels/CalendarViewModel';
-import TimeSelectorViewModel from 'matrix-public-archive-shared/viewmodels/TimeSelectorViewModel';
-import DeveloperOptionsContentViewModel from 'matrix-public-archive-shared/viewmodels/DeveloperOptionsContentViewModel';
-import RightPanelContentView from 'matrix-public-archive-shared/views/RightPanelContentView';
-import AvatarViewModel from 'matrix-public-archive-shared/viewmodels/AvatarViewModel';
-import { customTileClassForEntry } from 'matrix-public-archive-shared/lib/custom-tile-utilities';
-import stubPowerLevelsObservable from 'matrix-public-archive-shared/lib/stub-powerlevels-observable';
-import { TIME_PRECISION_VALUES } from 'matrix-public-archive-shared/lib/reference-values';
-import { areTimestampsFromSameUtcDay } from 'matrix-public-archive-shared/lib/timestamp-utilities';
+import ModalViewModel from 'matrix-public-archive-shared/viewmodels/ModalViewModel.js';
+import MatrixPublicArchiveURLCreator from 'matrix-public-archive-shared/lib/url-creator.js';
+import CalendarViewModel from 'matrix-public-archive-shared/viewmodels/CalendarViewModel.js';
+import TimeSelectorViewModel from 'matrix-public-archive-shared/viewmodels/TimeSelectorViewModel.js';
+import DeveloperOptionsContentViewModel from 'matrix-public-archive-shared/viewmodels/DeveloperOptionsContentViewModel.js';
+import RightPanelContentView from 'matrix-public-archive-shared/views/RightPanelContentView.js';
+import AvatarViewModel from 'matrix-public-archive-shared/viewmodels/AvatarViewModel.js';
+import { customTileClassForEntry } from 'matrix-public-archive-shared/lib/custom-tile-utilities.js';
+import stubPowerLevelsObservable from 'matrix-public-archive-shared/lib/stub-powerlevels-observable.js';
+import { TIME_PRECISION_VALUES } from 'matrix-public-archive-shared/lib/reference-values.js';
+import { areTimestampsFromSameUtcDay } from 'matrix-public-archive-shared/lib/timestamp-utilities.js';
 
 let txnCount = 0;
 function getFakeEventId() {

--- a/shared/viewmodels/AvatarViewModel.js
+++ b/shared/viewmodels/AvatarViewModel.js
@@ -1,7 +1,7 @@
-const { ViewModel, avatarInitials, getIdentifierColorNumber } = require('hydrogen-view-sdk');
+import { ViewModel, avatarInitials, getIdentifierColorNumber } from 'hydrogen-view-sdk';
 
-const assert = require('matrix-public-archive-shared/lib/assert');
-const { mxcUrlToHttpThumbnail } = require('matrix-public-archive-shared/lib/mxc-url-to-http');
+import assert from 'matrix-public-archive-shared/lib/assert';
+import { mxcUrlToHttpThumbnail } from 'matrix-public-archive-shared/lib/mxc-url-to-http';
 
 class AvatarViewModel extends ViewModel {
   constructor(options) {

--- a/shared/viewmodels/AvatarViewModel.js
+++ b/shared/viewmodels/AvatarViewModel.js
@@ -1,7 +1,7 @@
 import { ViewModel, avatarInitials, getIdentifierColorNumber } from 'hydrogen-view-sdk';
 
-import assert from 'matrix-public-archive-shared/lib/assert';
-import { mxcUrlToHttpThumbnail } from 'matrix-public-archive-shared/lib/mxc-url-to-http';
+import assert from 'matrix-public-archive-shared/lib/assert.js';
+import { mxcUrlToHttpThumbnail } from 'matrix-public-archive-shared/lib/mxc-url-to-http.js';
 
 class AvatarViewModel extends ViewModel {
   constructor(options) {

--- a/shared/viewmodels/AvatarViewModel.js
+++ b/shared/viewmodels/AvatarViewModel.js
@@ -45,4 +45,4 @@ class AvatarViewModel extends ViewModel {
   }
 }
 
-module.exports = AvatarViewModel;
+export default AvatarViewModel;

--- a/shared/viewmodels/AvatarViewModel.js
+++ b/shared/viewmodels/AvatarViewModel.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const { ViewModel, avatarInitials, getIdentifierColorNumber } = require('hydrogen-view-sdk');
 
 const assert = require('matrix-public-archive-shared/lib/assert');

--- a/shared/viewmodels/CalendarViewModel.js
+++ b/shared/viewmodels/CalendarViewModel.js
@@ -1,6 +1,6 @@
 import { ViewModel } from 'hydrogen-view-sdk';
 
-import assert from 'matrix-public-archive-shared/lib/assert';
+import assert from 'matrix-public-archive-shared/lib/assert.js';
 
 class CalendarViewModel extends ViewModel {
   constructor(options) {

--- a/shared/viewmodels/CalendarViewModel.js
+++ b/shared/viewmodels/CalendarViewModel.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const { ViewModel } = require('hydrogen-view-sdk');
 
 const assert = require('matrix-public-archive-shared/lib/assert');

--- a/shared/viewmodels/CalendarViewModel.js
+++ b/shared/viewmodels/CalendarViewModel.js
@@ -1,6 +1,6 @@
-const { ViewModel } = require('hydrogen-view-sdk');
+import { ViewModel } from 'hydrogen-view-sdk';
 
-const assert = require('matrix-public-archive-shared/lib/assert');
+import assert from 'matrix-public-archive-shared/lib/assert';
 
 class CalendarViewModel extends ViewModel {
   constructor(options) {

--- a/shared/viewmodels/CalendarViewModel.js
+++ b/shared/viewmodels/CalendarViewModel.js
@@ -70,4 +70,4 @@ class CalendarViewModel extends ViewModel {
   }
 }
 
-module.exports = CalendarViewModel;
+export default CalendarViewModel;

--- a/shared/viewmodels/DeveloperOptionsContentViewModel.js
+++ b/shared/viewmodels/DeveloperOptionsContentViewModel.js
@@ -1,4 +1,4 @@
-const { ViewModel } = require('hydrogen-view-sdk');
+import { ViewModel } from 'hydrogen-view-sdk';
 
 const DEBUG_ACTIVE_DATE_INTERSECTION_OBSERVER_LOCAL_STORAGE_KEY =
   'debugActiveDateIntersectionObserver';

--- a/shared/viewmodels/DeveloperOptionsContentViewModel.js
+++ b/shared/viewmodels/DeveloperOptionsContentViewModel.js
@@ -41,4 +41,4 @@ class DeveloperOptionsContentViewModel extends ViewModel {
   }
 }
 
-module.exports = DeveloperOptionsContentViewModel;
+export default DeveloperOptionsContentViewModel;

--- a/shared/viewmodels/DeveloperOptionsContentViewModel.js
+++ b/shared/viewmodels/DeveloperOptionsContentViewModel.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const { ViewModel } = require('hydrogen-view-sdk');
 
 const DEBUG_ACTIVE_DATE_INTERSECTION_OBSERVER_LOCAL_STORAGE_KEY =

--- a/shared/viewmodels/HomeserverSelectionModalContentViewModel.js
+++ b/shared/viewmodels/HomeserverSelectionModalContentViewModel.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const { ViewModel } = require('hydrogen-view-sdk');
 
 class HomeserverSelectionModalContentViewModel extends ViewModel {

--- a/shared/viewmodels/HomeserverSelectionModalContentViewModel.js
+++ b/shared/viewmodels/HomeserverSelectionModalContentViewModel.js
@@ -1,4 +1,4 @@
-const { ViewModel } = require('hydrogen-view-sdk');
+import { ViewModel } from 'hydrogen-view-sdk';
 
 class HomeserverSelectionModalContentViewModel extends ViewModel {
   constructor(options) {

--- a/shared/viewmodels/HomeserverSelectionModalContentViewModel.js
+++ b/shared/viewmodels/HomeserverSelectionModalContentViewModel.js
@@ -13,4 +13,4 @@ class HomeserverSelectionModalContentViewModel extends ViewModel {
   }
 }
 
-module.exports = HomeserverSelectionModalContentViewModel;
+export default HomeserverSelectionModalContentViewModel;

--- a/shared/viewmodels/JumpToNextActivitySummaryTileViewModel.js
+++ b/shared/viewmodels/JumpToNextActivitySummaryTileViewModel.js
@@ -1,8 +1,8 @@
 import { SimpleTile } from 'hydrogen-view-sdk';
 
-import { DIRECTION } from 'matrix-public-archive-shared/lib/reference-values';
-import MatrixPublicArchiveURLCreator from 'matrix-public-archive-shared/lib/url-creator';
-import assert from '../lib/assert';
+import { DIRECTION } from 'matrix-public-archive-shared/lib/reference-values.js';
+import MatrixPublicArchiveURLCreator from 'matrix-public-archive-shared/lib/url-creator.js';
+import assert from '../lib/assert.js';
 
 class JumpToNextActivitySummaryTileViewModel extends SimpleTile {
   constructor(entry, options) {

--- a/shared/viewmodels/JumpToNextActivitySummaryTileViewModel.js
+++ b/shared/viewmodels/JumpToNextActivitySummaryTileViewModel.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const { SimpleTile } = require('hydrogen-view-sdk');
 
 const { DIRECTION } = require('matrix-public-archive-shared/lib/reference-values');

--- a/shared/viewmodels/JumpToNextActivitySummaryTileViewModel.js
+++ b/shared/viewmodels/JumpToNextActivitySummaryTileViewModel.js
@@ -1,8 +1,8 @@
-const { SimpleTile } = require('hydrogen-view-sdk');
+import { SimpleTile } from 'hydrogen-view-sdk';
 
-const { DIRECTION } = require('matrix-public-archive-shared/lib/reference-values');
-const MatrixPublicArchiveURLCreator = require('matrix-public-archive-shared/lib/url-creator');
-const assert = require('../lib/assert');
+import { DIRECTION } from 'matrix-public-archive-shared/lib/reference-values';
+import MatrixPublicArchiveURLCreator from 'matrix-public-archive-shared/lib/url-creator';
+import assert from '../lib/assert';
 
 class JumpToNextActivitySummaryTileViewModel extends SimpleTile {
   constructor(entry, options) {

--- a/shared/viewmodels/JumpToNextActivitySummaryTileViewModel.js
+++ b/shared/viewmodels/JumpToNextActivitySummaryTileViewModel.js
@@ -60,4 +60,4 @@ class JumpToNextActivitySummaryTileViewModel extends SimpleTile {
   }
 }
 
-module.exports = JumpToNextActivitySummaryTileViewModel;
+export default JumpToNextActivitySummaryTileViewModel;

--- a/shared/viewmodels/JumpToPreviousActivitySummaryTileViewModel.js
+++ b/shared/viewmodels/JumpToPreviousActivitySummaryTileViewModel.js
@@ -1,8 +1,8 @@
-const { SimpleTile } = require('hydrogen-view-sdk');
+import { SimpleTile } from 'hydrogen-view-sdk';
 
-const { DIRECTION } = require('matrix-public-archive-shared/lib/reference-values');
-const MatrixPublicArchiveURLCreator = require('matrix-public-archive-shared/lib/url-creator');
-const assert = require('../lib/assert');
+import { DIRECTION } from 'matrix-public-archive-shared/lib/reference-values';
+import MatrixPublicArchiveURLCreator from 'matrix-public-archive-shared/lib/url-creator';
+import assert from '../lib/assert';
 
 class JumpToPreviousActivitySummaryTileViewModel extends SimpleTile {
   constructor(entry, options) {

--- a/shared/viewmodels/JumpToPreviousActivitySummaryTileViewModel.js
+++ b/shared/viewmodels/JumpToPreviousActivitySummaryTileViewModel.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const { SimpleTile } = require('hydrogen-view-sdk');
 
 const { DIRECTION } = require('matrix-public-archive-shared/lib/reference-values');

--- a/shared/viewmodels/JumpToPreviousActivitySummaryTileViewModel.js
+++ b/shared/viewmodels/JumpToPreviousActivitySummaryTileViewModel.js
@@ -52,4 +52,4 @@ class JumpToPreviousActivitySummaryTileViewModel extends SimpleTile {
   }
 }
 
-module.exports = JumpToPreviousActivitySummaryTileViewModel;
+export default JumpToPreviousActivitySummaryTileViewModel;

--- a/shared/viewmodels/JumpToPreviousActivitySummaryTileViewModel.js
+++ b/shared/viewmodels/JumpToPreviousActivitySummaryTileViewModel.js
@@ -1,8 +1,8 @@
 import { SimpleTile } from 'hydrogen-view-sdk';
 
-import { DIRECTION } from 'matrix-public-archive-shared/lib/reference-values';
-import MatrixPublicArchiveURLCreator from 'matrix-public-archive-shared/lib/url-creator';
-import assert from '../lib/assert';
+import { DIRECTION } from 'matrix-public-archive-shared/lib/reference-values.js';
+import MatrixPublicArchiveURLCreator from 'matrix-public-archive-shared/lib/url-creator.js';
+import assert from '../lib/assert.js';
 
 class JumpToPreviousActivitySummaryTileViewModel extends SimpleTile {
   constructor(entry, options) {

--- a/shared/viewmodels/ModalViewModel.js
+++ b/shared/viewmodels/ModalViewModel.js
@@ -33,4 +33,4 @@ class ModalViewModel extends ViewModel {
   }
 }
 
-module.exports = ModalViewModel;
+export default ModalViewModel;

--- a/shared/viewmodels/ModalViewModel.js
+++ b/shared/viewmodels/ModalViewModel.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const { ViewModel } = require('hydrogen-view-sdk');
 
 class ModalViewModel extends ViewModel {

--- a/shared/viewmodels/ModalViewModel.js
+++ b/shared/viewmodels/ModalViewModel.js
@@ -1,4 +1,4 @@
-const { ViewModel } = require('hydrogen-view-sdk');
+import { ViewModel } from 'hydrogen-view-sdk';
 
 class ModalViewModel extends ViewModel {
   constructor(options) {

--- a/shared/viewmodels/RoomDirectoryViewModel.js
+++ b/shared/viewmodels/RoomDirectoryViewModel.js
@@ -1,9 +1,9 @@
-const { ViewModel, ObservableArray } = require('hydrogen-view-sdk');
+import { ViewModel, ObservableArray } from 'hydrogen-view-sdk';
 
-const assert = require('matrix-public-archive-shared/lib/assert');
+import assert from 'matrix-public-archive-shared/lib/assert';
 
-const ModalViewModel = require('matrix-public-archive-shared/viewmodels/ModalViewModel');
-const HomeserverSelectionModalContentViewModel = require('matrix-public-archive-shared/viewmodels/HomeserverSelectionModalContentViewModel');
+import ModalViewModel from 'matrix-public-archive-shared/viewmodels/ModalViewModel';
+import HomeserverSelectionModalContentViewModel from 'matrix-public-archive-shared/viewmodels/HomeserverSelectionModalContentViewModel';
 
 const DEFAULT_SERVER_LIST = ['matrix.org', 'gitter.im', 'libera.chat'];
 

--- a/shared/viewmodels/RoomDirectoryViewModel.js
+++ b/shared/viewmodels/RoomDirectoryViewModel.js
@@ -1,9 +1,9 @@
 import { ViewModel, ObservableArray } from 'hydrogen-view-sdk';
 
-import assert from 'matrix-public-archive-shared/lib/assert';
+import assert from 'matrix-public-archive-shared/lib/assert.js';
 
-import ModalViewModel from 'matrix-public-archive-shared/viewmodels/ModalViewModel';
-import HomeserverSelectionModalContentViewModel from 'matrix-public-archive-shared/viewmodels/HomeserverSelectionModalContentViewModel';
+import ModalViewModel from 'matrix-public-archive-shared/viewmodels/ModalViewModel.js';
+import HomeserverSelectionModalContentViewModel from 'matrix-public-archive-shared/viewmodels/HomeserverSelectionModalContentViewModel.js';
 
 const DEFAULT_SERVER_LIST = ['matrix.org', 'gitter.im', 'libera.chat'];
 

--- a/shared/viewmodels/RoomDirectoryViewModel.js
+++ b/shared/viewmodels/RoomDirectoryViewModel.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const { ViewModel, ObservableArray } = require('hydrogen-view-sdk');
 
 const assert = require('matrix-public-archive-shared/lib/assert');

--- a/shared/viewmodels/RoomDirectoryViewModel.js
+++ b/shared/viewmodels/RoomDirectoryViewModel.js
@@ -287,4 +287,4 @@ class RoomDirectoryViewModel extends ViewModel {
   }
 }
 
-module.exports = RoomDirectoryViewModel;
+export default RoomDirectoryViewModel;

--- a/shared/viewmodels/TimeSelectorViewModel.js
+++ b/shared/viewmodels/TimeSelectorViewModel.js
@@ -81,4 +81,4 @@ class TimeSelectorViewModel extends ViewModel {
   }
 }
 
-module.exports = TimeSelectorViewModel;
+export default TimeSelectorViewModel;

--- a/shared/viewmodels/TimeSelectorViewModel.js
+++ b/shared/viewmodels/TimeSelectorViewModel.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const { ViewModel } = require('hydrogen-view-sdk');
 const assert = require('matrix-public-archive-shared/lib/assert');
 const { TIME_PRECISION_VALUES } = require('matrix-public-archive-shared/lib/reference-values');

--- a/shared/viewmodels/TimeSelectorViewModel.js
+++ b/shared/viewmodels/TimeSelectorViewModel.js
@@ -1,6 +1,6 @@
-const { ViewModel } = require('hydrogen-view-sdk');
-const assert = require('matrix-public-archive-shared/lib/assert');
-const { TIME_PRECISION_VALUES } = require('matrix-public-archive-shared/lib/reference-values');
+import { ViewModel } from 'hydrogen-view-sdk';
+import assert from 'matrix-public-archive-shared/lib/assert';
+import { TIME_PRECISION_VALUES } from 'matrix-public-archive-shared/lib/reference-values';
 
 class TimeSelectorViewModel extends ViewModel {
   constructor(options) {

--- a/shared/viewmodels/TimeSelectorViewModel.js
+++ b/shared/viewmodels/TimeSelectorViewModel.js
@@ -1,6 +1,6 @@
 import { ViewModel } from 'hydrogen-view-sdk';
-import assert from 'matrix-public-archive-shared/lib/assert';
-import { TIME_PRECISION_VALUES } from 'matrix-public-archive-shared/lib/reference-values';
+import assert from 'matrix-public-archive-shared/lib/assert.js';
+import { TIME_PRECISION_VALUES } from 'matrix-public-archive-shared/lib/reference-values.js';
 
 class TimeSelectorViewModel extends ViewModel {
   constructor(options) {

--- a/shared/views/ArchiveRoomView.js
+++ b/shared/views/ArchiveRoomView.js
@@ -1,14 +1,12 @@
-const {
+import {
   TemplateView,
   AvatarView,
   TimelineView,
   RightPanelView,
   LightboxView,
-} = require('hydrogen-view-sdk');
+} from 'hydrogen-view-sdk';
 
-const {
-  customViewClassForTile,
-} = require('matrix-public-archive-shared/lib/custom-tile-utilities');
+import { customViewClassForTile } from 'matrix-public-archive-shared/lib/custom-tile-utilities';
 
 import DeveloperOptionsContentView from 'matrix-public-archive-shared/views/DeveloperOptionsContentView';
 import ModalView from 'matrix-public-archive-shared/views/ModalView';

--- a/shared/views/ArchiveRoomView.js
+++ b/shared/views/ArchiveRoomView.js
@@ -6,10 +6,10 @@ import {
   LightboxView,
 } from 'hydrogen-view-sdk';
 
-import { customViewClassForTile } from 'matrix-public-archive-shared/lib/custom-tile-utilities';
+import { customViewClassForTile } from 'matrix-public-archive-shared/lib/custom-tile-utilities.js';
 
-import DeveloperOptionsContentView from 'matrix-public-archive-shared/views/DeveloperOptionsContentView';
-import ModalView from 'matrix-public-archive-shared/views/ModalView';
+import DeveloperOptionsContentView from 'matrix-public-archive-shared/views/DeveloperOptionsContentView.js';
+import ModalView from 'matrix-public-archive-shared/views/ModalView.js';
 
 class RoomHeaderView extends TemplateView {
   render(t, vm) {

--- a/shared/views/ArchiveRoomView.js
+++ b/shared/views/ArchiveRoomView.js
@@ -10,8 +10,8 @@ const {
   customViewClassForTile,
 } = require('matrix-public-archive-shared/lib/custom-tile-utilities');
 
-const DeveloperOptionsContentView = require('matrix-public-archive-shared/views/DeveloperOptionsContentView');
-const ModalView = require('matrix-public-archive-shared/views/ModalView');
+import DeveloperOptionsContentView from 'matrix-public-archive-shared/views/DeveloperOptionsContentView';
+import ModalView from 'matrix-public-archive-shared/views/ModalView';
 
 class RoomHeaderView extends TemplateView {
   render(t, vm) {

--- a/shared/views/ArchiveRoomView.js
+++ b/shared/views/ArchiveRoomView.js
@@ -212,4 +212,4 @@ class ArchiveRoomView extends TemplateView {
   }
 }
 
-module.exports = ArchiveRoomView;
+export default ArchiveRoomView;

--- a/shared/views/ArchiveRoomView.js
+++ b/shared/views/ArchiveRoomView.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const {
   TemplateView,
   AvatarView,

--- a/shared/views/CalendarView.js
+++ b/shared/views/CalendarView.js
@@ -1,5 +1,3 @@
-'use strict';
-
 // Be mindful to do all date operations in UTC (the archive is all in UTC date/times)
 
 const { TemplateView } = require('hydrogen-view-sdk');

--- a/shared/views/CalendarView.js
+++ b/shared/views/CalendarView.js
@@ -1,9 +1,7 @@
 // Be mindful to do all date operations in UTC (the archive is all in UTC date/times)
 
 import { TemplateView } from 'hydrogen-view-sdk';
-const {
-  areTimestampsFromSameUtcDay,
-} = require('matrix-public-archive-shared/lib/timestamp-utilities');
+import { areTimestampsFromSameUtcDay } from 'matrix-public-archive-shared/lib/timestamp-utilities';
 
 // Get the number of days in the given month where the `inputDate` lies.
 //

--- a/shared/views/CalendarView.js
+++ b/shared/views/CalendarView.js
@@ -1,6 +1,6 @@
 // Be mindful to do all date operations in UTC (the archive is all in UTC date/times)
 
-const { TemplateView } = require('hydrogen-view-sdk');
+import { TemplateView } from 'hydrogen-view-sdk';
 const {
   areTimestampsFromSameUtcDay,
 } = require('matrix-public-archive-shared/lib/timestamp-utilities');

--- a/shared/views/CalendarView.js
+++ b/shared/views/CalendarView.js
@@ -1,7 +1,7 @@
 // Be mindful to do all date operations in UTC (the archive is all in UTC date/times)
 
 import { TemplateView } from 'hydrogen-view-sdk';
-import { areTimestampsFromSameUtcDay } from 'matrix-public-archive-shared/lib/timestamp-utilities';
+import { areTimestampsFromSameUtcDay } from 'matrix-public-archive-shared/lib/timestamp-utilities.js';
 
 // Get the number of days in the given month where the `inputDate` lies.
 //

--- a/shared/views/CalendarView.js
+++ b/shared/views/CalendarView.js
@@ -201,4 +201,4 @@ class CalendarView extends TemplateView {
   }
 }
 
-module.exports = CalendarView;
+export default CalendarView;

--- a/shared/views/DeveloperOptionsContentView.js
+++ b/shared/views/DeveloperOptionsContentView.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const { TemplateView } = require('hydrogen-view-sdk');
 
 class DeveloperOptionsContentView extends TemplateView {

--- a/shared/views/DeveloperOptionsContentView.js
+++ b/shared/views/DeveloperOptionsContentView.js
@@ -1,4 +1,4 @@
-const { TemplateView } = require('hydrogen-view-sdk');
+import { TemplateView } from 'hydrogen-view-sdk';
 
 class DeveloperOptionsContentView extends TemplateView {
   render(t, vm) {

--- a/shared/views/DeveloperOptionsContentView.js
+++ b/shared/views/DeveloperOptionsContentView.js
@@ -31,4 +31,4 @@ class DeveloperOptionsContentView extends TemplateView {
   }
 }
 
-module.exports = DeveloperOptionsContentView;
+export default DeveloperOptionsContentView;

--- a/shared/views/HomeserverSelectionModalContentView.js
+++ b/shared/views/HomeserverSelectionModalContentView.js
@@ -31,4 +31,4 @@ class HomeserverSelectionModalContentView extends TemplateView {
   }
 }
 
-module.exports = HomeserverSelectionModalContentView;
+export default HomeserverSelectionModalContentView;

--- a/shared/views/HomeserverSelectionModalContentView.js
+++ b/shared/views/HomeserverSelectionModalContentView.js
@@ -1,4 +1,4 @@
-const { TemplateView } = require('hydrogen-view-sdk');
+import { TemplateView } from 'hydrogen-view-sdk';
 
 class HomeserverSelectionModalContentView extends TemplateView {
   render(t, vm) {

--- a/shared/views/HomeserverSelectionModalContentView.js
+++ b/shared/views/HomeserverSelectionModalContentView.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const { TemplateView } = require('hydrogen-view-sdk');
 
 class HomeserverSelectionModalContentView extends TemplateView {

--- a/shared/views/JumpToNextActivitySummaryTileView.js
+++ b/shared/views/JumpToNextActivitySummaryTileView.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const { TemplateView } = require('hydrogen-view-sdk');
 
 class JumpToNextActivitySummaryTileView extends TemplateView {

--- a/shared/views/JumpToNextActivitySummaryTileView.js
+++ b/shared/views/JumpToNextActivitySummaryTileView.js
@@ -71,4 +71,4 @@ class JumpToNextActivitySummaryTileView extends TemplateView {
   }
 }
 
-module.exports = JumpToNextActivitySummaryTileView;
+export default JumpToNextActivitySummaryTileView;

--- a/shared/views/JumpToNextActivitySummaryTileView.js
+++ b/shared/views/JumpToNextActivitySummaryTileView.js
@@ -1,4 +1,4 @@
-const { TemplateView } = require('hydrogen-view-sdk');
+import { TemplateView } from 'hydrogen-view-sdk';
 
 class JumpToNextActivitySummaryTileView extends TemplateView {
   render(t, vm) {

--- a/shared/views/JumpToPreviousActivitySummaryTileView.js
+++ b/shared/views/JumpToPreviousActivitySummaryTileView.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const { TemplateView } = require('hydrogen-view-sdk');
 
 class JumpToPreviousActivitySummaryTileView extends TemplateView {

--- a/shared/views/JumpToPreviousActivitySummaryTileView.js
+++ b/shared/views/JumpToPreviousActivitySummaryTileView.js
@@ -38,4 +38,4 @@ class JumpToPreviousActivitySummaryTileView extends TemplateView {
   }
 }
 
-module.exports = JumpToPreviousActivitySummaryTileView;
+export default JumpToPreviousActivitySummaryTileView;

--- a/shared/views/JumpToPreviousActivitySummaryTileView.js
+++ b/shared/views/JumpToPreviousActivitySummaryTileView.js
@@ -1,4 +1,4 @@
-const { TemplateView } = require('hydrogen-view-sdk');
+import { TemplateView } from 'hydrogen-view-sdk';
 
 class JumpToPreviousActivitySummaryTileView extends TemplateView {
   render(t, vm) {

--- a/shared/views/MatrixLogoView.js
+++ b/shared/views/MatrixLogoView.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const { TemplateView } = require('hydrogen-view-sdk');
 
 class MatrixLogoView extends TemplateView {

--- a/shared/views/MatrixLogoView.js
+++ b/shared/views/MatrixLogoView.js
@@ -38,4 +38,4 @@ class MatrixLogoView extends TemplateView {
   }
 }
 
-module.exports = MatrixLogoView;
+export default MatrixLogoView;

--- a/shared/views/MatrixLogoView.js
+++ b/shared/views/MatrixLogoView.js
@@ -1,4 +1,4 @@
-const { TemplateView } = require('hydrogen-view-sdk');
+import { TemplateView } from 'hydrogen-view-sdk';
 
 class MatrixLogoView extends TemplateView {
   render(t) {

--- a/shared/views/ModalView.js
+++ b/shared/views/ModalView.js
@@ -1,5 +1,5 @@
 import { TemplateView } from 'hydrogen-view-sdk';
-import assert from '../lib/assert';
+import assert from '../lib/assert.js';
 
 class ModalView extends TemplateView {
   constructor(ContentViewClass, vm) {

--- a/shared/views/ModalView.js
+++ b/shared/views/ModalView.js
@@ -1,5 +1,5 @@
-const { TemplateView } = require('hydrogen-view-sdk');
-const assert = require('../lib/assert');
+import { TemplateView } from 'hydrogen-view-sdk';
+import assert from '../lib/assert';
 
 class ModalView extends TemplateView {
   constructor(ContentViewClass, vm) {

--- a/shared/views/ModalView.js
+++ b/shared/views/ModalView.js
@@ -124,4 +124,4 @@ class ModalView extends TemplateView {
   }
 }
 
-module.exports = ModalView;
+export default ModalView;

--- a/shared/views/ModalView.js
+++ b/shared/views/ModalView.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const { TemplateView } = require('hydrogen-view-sdk');
 const assert = require('../lib/assert');
 

--- a/shared/views/RightPanelContentView.js
+++ b/shared/views/RightPanelContentView.js
@@ -1,8 +1,8 @@
 import { TemplateView } from 'hydrogen-view-sdk';
 
-import CalendarView from 'matrix-public-archive-shared/views/CalendarView';
-import TimeSelectorView from 'matrix-public-archive-shared/views/TimeSelectorView';
-import assert from 'matrix-public-archive-shared/lib/assert';
+import CalendarView from 'matrix-public-archive-shared/views/CalendarView.js';
+import TimeSelectorView from 'matrix-public-archive-shared/views/TimeSelectorView.js';
+import assert from 'matrix-public-archive-shared/lib/assert.js';
 
 class RightPanelContentView extends TemplateView {
   render(t, vm) {

--- a/shared/views/RightPanelContentView.js
+++ b/shared/views/RightPanelContentView.js
@@ -1,8 +1,8 @@
-const { TemplateView } = require('hydrogen-view-sdk');
+import { TemplateView } from 'hydrogen-view-sdk';
 
-const CalendarView = require('matrix-public-archive-shared/views/CalendarView');
-const TimeSelectorView = require('matrix-public-archive-shared/views/TimeSelectorView');
-const assert = require('matrix-public-archive-shared/lib/assert');
+import CalendarView from 'matrix-public-archive-shared/views/CalendarView';
+import TimeSelectorView from 'matrix-public-archive-shared/views/TimeSelectorView';
+import assert from 'matrix-public-archive-shared/lib/assert';
 
 class RightPanelContentView extends TemplateView {
   render(t, vm) {

--- a/shared/views/RightPanelContentView.js
+++ b/shared/views/RightPanelContentView.js
@@ -59,4 +59,4 @@ class RightPanelContentView extends TemplateView {
   }
 }
 
-module.exports = RightPanelContentView;
+export default RightPanelContentView;

--- a/shared/views/RightPanelContentView.js
+++ b/shared/views/RightPanelContentView.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const { TemplateView } = require('hydrogen-view-sdk');
 
 const CalendarView = require('matrix-public-archive-shared/views/CalendarView');

--- a/shared/views/RoomCardView.js
+++ b/shared/views/RoomCardView.js
@@ -1,5 +1,5 @@
-const { TemplateView, AvatarView } = require('hydrogen-view-sdk');
-const AvatarViewModel = require('../viewmodels/AvatarViewModel');
+import { TemplateView, AvatarView } from 'hydrogen-view-sdk';
+import AvatarViewModel from '../viewmodels/AvatarViewModel';
 
 class RoomCardView extends TemplateView {
   render(t, vm) {

--- a/shared/views/RoomCardView.js
+++ b/shared/views/RoomCardView.js
@@ -92,4 +92,4 @@ class RoomCardView extends TemplateView {
   }
 }
 
-module.exports = RoomCardView;
+export default RoomCardView;

--- a/shared/views/RoomCardView.js
+++ b/shared/views/RoomCardView.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const { TemplateView, AvatarView } = require('hydrogen-view-sdk');
 const AvatarViewModel = require('../viewmodels/AvatarViewModel');
 

--- a/shared/views/RoomCardView.js
+++ b/shared/views/RoomCardView.js
@@ -1,5 +1,5 @@
 import { TemplateView, AvatarView } from 'hydrogen-view-sdk';
-import AvatarViewModel from '../viewmodels/AvatarViewModel';
+import AvatarViewModel from '../viewmodels/AvatarViewModel.js';
 
 class RoomCardView extends TemplateView {
   render(t, vm) {

--- a/shared/views/RoomDirectoryView.js
+++ b/shared/views/RoomDirectoryView.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const { TemplateView, ListView, text } = require('hydrogen-view-sdk');
 
 const ModalView = require('matrix-public-archive-shared/views/ModalView');

--- a/shared/views/RoomDirectoryView.js
+++ b/shared/views/RoomDirectoryView.js
@@ -1,9 +1,9 @@
 import { TemplateView, ListView, text } from 'hydrogen-view-sdk';
 
-import ModalView from 'matrix-public-archive-shared/views/ModalView';
-import HomeserverSelectionModalContentView from './HomeserverSelectionModalContentView';
-import MatrixLogoView from './MatrixLogoView';
-import RoomCardView from './RoomCardView';
+import ModalView from 'matrix-public-archive-shared/views/ModalView.js';
+import HomeserverSelectionModalContentView from './HomeserverSelectionModalContentView.js';
+import MatrixLogoView from './MatrixLogoView.js';
+import RoomCardView from './RoomCardView.js';
 
 class RoomDirectoryView extends TemplateView {
   render(t, vm) {

--- a/shared/views/RoomDirectoryView.js
+++ b/shared/views/RoomDirectoryView.js
@@ -306,4 +306,4 @@ class RoomDirectoryView extends TemplateView {
   }
 }
 
-module.exports = RoomDirectoryView;
+export default RoomDirectoryView;

--- a/shared/views/RoomDirectoryView.js
+++ b/shared/views/RoomDirectoryView.js
@@ -1,9 +1,9 @@
-const { TemplateView, ListView, text } = require('hydrogen-view-sdk');
+import { TemplateView, ListView, text } from 'hydrogen-view-sdk';
 
-const ModalView = require('matrix-public-archive-shared/views/ModalView');
-const HomeserverSelectionModalContentView = require('./HomeserverSelectionModalContentView');
-const MatrixLogoView = require('./MatrixLogoView');
-const RoomCardView = require('./RoomCardView');
+import ModalView from 'matrix-public-archive-shared/views/ModalView';
+import HomeserverSelectionModalContentView from './HomeserverSelectionModalContentView';
+import MatrixLogoView from './MatrixLogoView';
+import RoomCardView from './RoomCardView';
 
 class RoomDirectoryView extends TemplateView {
   render(t, vm) {

--- a/shared/views/TimeSelectorView.js
+++ b/shared/views/TimeSelectorView.js
@@ -1,11 +1,11 @@
-const assert = require('matrix-public-archive-shared/lib/assert');
-const { TemplateView } = require('hydrogen-view-sdk');
+import assert from 'matrix-public-archive-shared/lib/assert';
+import { TemplateView } from 'hydrogen-view-sdk';
 const {
   MS_LOOKUP,
   TIME_PRECISION_VALUES,
 } = require('matrix-public-archive-shared/lib/reference-values');
 const { ONE_DAY_IN_MS, ONE_HOUR_IN_MS, ONE_MINUTE_IN_MS, ONE_SECOND_IN_MS } = MS_LOOKUP;
-const { getUtcStartOfDayTs } = require('matrix-public-archive-shared/lib/timestamp-utilities');
+import { getUtcStartOfDayTs } from 'matrix-public-archive-shared/lib/timestamp-utilities';
 
 function clamp(input, min, max) {
   assert(input !== undefined);

--- a/shared/views/TimeSelectorView.js
+++ b/shared/views/TimeSelectorView.js
@@ -1,11 +1,11 @@
-import assert from 'matrix-public-archive-shared/lib/assert';
+import assert from 'matrix-public-archive-shared/lib/assert.js';
 import { TemplateView } from 'hydrogen-view-sdk';
 import {
   MS_LOOKUP,
   TIME_PRECISION_VALUES,
-} from 'matrix-public-archive-shared/lib/reference-values';
+} from 'matrix-public-archive-shared/lib/reference-values.js';
 const { ONE_DAY_IN_MS, ONE_HOUR_IN_MS, ONE_MINUTE_IN_MS, ONE_SECOND_IN_MS } = MS_LOOKUP;
-import { getUtcStartOfDayTs } from 'matrix-public-archive-shared/lib/timestamp-utilities';
+import { getUtcStartOfDayTs } from 'matrix-public-archive-shared/lib/timestamp-utilities.js';
 
 function clamp(input, min, max) {
   assert(input !== undefined);

--- a/shared/views/TimeSelectorView.js
+++ b/shared/views/TimeSelectorView.js
@@ -509,4 +509,4 @@ class TimeSelectorView extends TemplateView {
   }
 }
 
-module.exports = TimeSelectorView;
+export default TimeSelectorView;

--- a/shared/views/TimeSelectorView.js
+++ b/shared/views/TimeSelectorView.js
@@ -1,9 +1,9 @@
 import assert from 'matrix-public-archive-shared/lib/assert';
 import { TemplateView } from 'hydrogen-view-sdk';
-const {
+import {
   MS_LOOKUP,
   TIME_PRECISION_VALUES,
-} = require('matrix-public-archive-shared/lib/reference-values');
+} from 'matrix-public-archive-shared/lib/reference-values';
 const { ONE_DAY_IN_MS, ONE_HOUR_IN_MS, ONE_MINUTE_IN_MS, ONE_SECOND_IN_MS } = MS_LOOKUP;
 import { getUtcStartOfDayTs } from 'matrix-public-archive-shared/lib/timestamp-utilities';
 

--- a/shared/views/TimeSelectorView.js
+++ b/shared/views/TimeSelectorView.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const assert = require('matrix-public-archive-shared/lib/assert');
 const { TemplateView } = require('hydrogen-view-sdk');
 const {

--- a/test/.eslintrc.json
+++ b/test/.eslintrc.json
@@ -10,6 +10,6 @@
       "error",
       "safe"
     ],
-    "node/no-unpublished-import": "off"
+    "n/no-unpublished-import": "off"
   }
 }

--- a/test/.eslintrc.json
+++ b/test/.eslintrc.json
@@ -9,6 +9,7 @@
     "strict": [
       "error",
       "safe"
-    ]
+    ],
+    "node/no-unpublished-import": "off"
   }
 }

--- a/test/e2e-tests.js
+++ b/test/e2e-tests.js
@@ -14,14 +14,14 @@ import RethrownError from '../server/lib/rethrown-error';
 import MatrixPublicArchiveURLCreator from 'matrix-public-archive-shared/lib/url-creator';
 import { fetchEndpointAsText, fetchEndpointAsJson } from '../server/lib/fetch-endpoint';
 import config from '../server/lib/config';
-const {
+import {
   MS_LOOKUP,
   TIME_PRECISION_VALUES,
   DIRECTION,
-} = require('matrix-public-archive-shared/lib/reference-values');
+} from 'matrix-public-archive-shared/lib/reference-values';
 const { ONE_DAY_IN_MS, ONE_HOUR_IN_MS, ONE_MINUTE_IN_MS, ONE_SECOND_IN_MS } = MS_LOOKUP;
 
-const {
+import {
   getTestClientForAs,
   getTestClientForHs,
   createTestRoom,
@@ -34,7 +34,7 @@ const {
   getMessagesInRoom,
   updateProfile,
   uploadContent,
-} = require('./test-utils/client-utils');
+} from './test-utils/client-utils';
 import TestError from './test-utils/test-error';
 import parseRoomDayMessageStructure from './test-utils/parse-room-day-message-structure';
 import parseArchiveUrlForRoom from './test-utils/parse-archive-url-for-room';
@@ -79,9 +79,9 @@ function assertExpectedTimePrecisionAgainstUrl(expectedTimePrecision, url) {
 
 describe('matrix-public-archive', () => {
   let server;
-  before(() => {
+  before(async () => {
     // Start the archive server
-    server = require('../server/server');
+    server = await import('../server/server');
   });
 
   after(() => {

--- a/test/e2e-tests.js
+++ b/test/e2e-tests.js
@@ -1,18 +1,18 @@
 process.env.NODE_ENV = 'test';
 
-const assert = require('assert');
-const path = require('path');
-const http = require('http');
-const urlJoin = require('url-join');
-const escapeStringRegexp = require('escape-string-regexp');
-const { parseHTML } = require('linkedom');
+import assert from 'assert';
+import path from 'path';
+import http from 'http';
+import urlJoin from 'url-join';
+import escapeStringRegexp from 'escape-string-regexp';
+import { parseHTML } from 'linkedom';
 const { readFile } = require('fs').promises;
-const chalk = require('chalk');
+import chalk from 'chalk';
 
-const RethrownError = require('../server/lib/rethrown-error');
-const MatrixPublicArchiveURLCreator = require('matrix-public-archive-shared/lib/url-creator');
-const { fetchEndpointAsText, fetchEndpointAsJson } = require('../server/lib/fetch-endpoint');
-const config = require('../server/lib/config');
+import RethrownError from '../server/lib/rethrown-error';
+import MatrixPublicArchiveURLCreator from 'matrix-public-archive-shared/lib/url-creator';
+import { fetchEndpointAsText, fetchEndpointAsJson } from '../server/lib/fetch-endpoint';
+import config from '../server/lib/config';
 const {
   MS_LOOKUP,
   TIME_PRECISION_VALUES,
@@ -34,9 +34,9 @@ const {
   updateProfile,
   uploadContent,
 } = require('./test-utils/client-utils');
-const TestError = require('./test-utils/test-error');
-const parseRoomDayMessageStructure = require('./test-utils/parse-room-day-message-structure');
-const parseArchiveUrlForRoom = require('./test-utils/parse-archive-url-for-room');
+import TestError from './test-utils/test-error';
+import parseRoomDayMessageStructure from './test-utils/parse-room-day-message-structure';
+import parseArchiveUrlForRoom from './test-utils/parse-archive-url-for-room';
 
 const testMatrixServerUrl1 = config.get('testMatrixServerUrl1');
 const testMatrixServerUrl2 = config.get('testMatrixServerUrl2');

--- a/test/e2e-tests.js
+++ b/test/e2e-tests.js
@@ -81,7 +81,7 @@ describe('matrix-public-archive', () => {
   let server;
   before(async () => {
     // Start the archive server
-    server = await import('../server/server');
+    server = await import('../server/server.js');
   });
 
   after(() => {

--- a/test/e2e-tests.js
+++ b/test/e2e-tests.js
@@ -1,5 +1,3 @@
-'use strict';
-
 process.env.NODE_ENV = 'test';
 
 const assert = require('assert');

--- a/test/e2e-tests.js
+++ b/test/e2e-tests.js
@@ -7,7 +7,7 @@ import http from 'http';
 import urlJoin from 'url-join';
 import escapeStringRegexp from 'escape-string-regexp';
 import { parseHTML } from 'linkedom';
-const { readFile } = require('fs').promises;
+import { readFile } from 'node:fs/promises';
 import chalk from 'chalk';
 
 import RethrownError from '../server/lib/rethrown-error';

--- a/test/e2e-tests.js
+++ b/test/e2e-tests.js
@@ -1,6 +1,7 @@
 process.env.NODE_ENV = 'test';
 
 import assert from 'assert';
+import { fileURLToPath } from 'node:url';
 import path from 'path';
 import http from 'http';
 import urlJoin from 'url-join';
@@ -37,6 +38,8 @@ const {
 import TestError from './test-utils/test-error';
 import parseRoomDayMessageStructure from './test-utils/parse-room-day-message-structure';
 import parseArchiveUrlForRoom from './test-utils/parse-archive-url-for-room';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 const testMatrixServerUrl1 = config.get('testMatrixServerUrl1');
 const testMatrixServerUrl2 = config.get('testMatrixServerUrl2');

--- a/test/e2e-tests.js
+++ b/test/e2e-tests.js
@@ -10,15 +10,15 @@ import { parseHTML } from 'linkedom';
 import { readFile } from 'node:fs/promises';
 import chalk from 'chalk';
 
-import RethrownError from '../server/lib/rethrown-error';
-import MatrixPublicArchiveURLCreator from 'matrix-public-archive-shared/lib/url-creator';
-import { fetchEndpointAsText, fetchEndpointAsJson } from '../server/lib/fetch-endpoint';
-import config from '../server/lib/config';
+import RethrownError from '../server/lib/rethrown-error.js';
+import MatrixPublicArchiveURLCreator from 'matrix-public-archive-shared/lib/url-creator.js';
+import { fetchEndpointAsText, fetchEndpointAsJson } from '../server/lib/fetch-endpoint.js';
+import config from '../server/lib/config.js';
 import {
   MS_LOOKUP,
   TIME_PRECISION_VALUES,
   DIRECTION,
-} from 'matrix-public-archive-shared/lib/reference-values';
+} from 'matrix-public-archive-shared/lib/reference-values.js';
 const { ONE_DAY_IN_MS, ONE_HOUR_IN_MS, ONE_MINUTE_IN_MS, ONE_SECOND_IN_MS } = MS_LOOKUP;
 
 import {
@@ -34,10 +34,10 @@ import {
   getMessagesInRoom,
   updateProfile,
   uploadContent,
-} from './test-utils/client-utils';
-import TestError from './test-utils/test-error';
-import parseRoomDayMessageStructure from './test-utils/parse-room-day-message-structure';
-import parseArchiveUrlForRoom from './test-utils/parse-archive-url-for-room';
+} from './test-utils/client-utils.js';
+import TestError from './test-utils/test-error.js';
+import parseRoomDayMessageStructure from './test-utils/parse-room-day-message-structure.js';
+import parseArchiveUrlForRoom from './test-utils/parse-archive-url-for-room.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 

--- a/test/server/matrix-utils/get-server-name-from-matrix-room-id-or-alias-tests.js
+++ b/test/server/matrix-utils/get-server-name-from-matrix-room-id-or-alias-tests.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const assert = require('assert');
 
 const getServerNameFromMatrixRoomIdOrAlias = require('../../../server/lib/matrix-utils/get-server-name-from-matrix-room-id-or-alias');

--- a/test/server/matrix-utils/get-server-name-from-matrix-room-id-or-alias-tests.js
+++ b/test/server/matrix-utils/get-server-name-from-matrix-room-id-or-alias-tests.js
@@ -1,6 +1,6 @@
-const assert = require('assert');
+import assert from 'assert';
 
-const getServerNameFromMatrixRoomIdOrAlias = require('../../../server/lib/matrix-utils/get-server-name-from-matrix-room-id-or-alias');
+import getServerNameFromMatrixRoomIdOrAlias from '../../../server/lib/matrix-utils/get-server-name-from-matrix-room-id-or-alias';
 
 describe('getServerNameFromMatrixRoomIdOrAlias', () => {
   // Some examples from https://spec.matrix.org/v1.5/appendices/#server-name

--- a/test/server/matrix-utils/get-server-name-from-matrix-room-id-or-alias-tests.js
+++ b/test/server/matrix-utils/get-server-name-from-matrix-room-id-or-alias-tests.js
@@ -1,6 +1,6 @@
 import assert from 'assert';
 
-import getServerNameFromMatrixRoomIdOrAlias from '../../../server/lib/matrix-utils/get-server-name-from-matrix-room-id-or-alias';
+import getServerNameFromMatrixRoomIdOrAlias from '../../../server/lib/matrix-utils/get-server-name-from-matrix-room-id-or-alias.js';
 
 describe('getServerNameFromMatrixRoomIdOrAlias', () => {
   // Some examples from https://spec.matrix.org/v1.5/appendices/#server-name

--- a/test/shared/lib/timestamp-utilties-tests.js
+++ b/test/shared/lib/timestamp-utilties-tests.js
@@ -1,4 +1,4 @@
-const assert = require('assert');
+import assert from 'assert';
 
 const {
   roundUpTimestampToUtcDay,

--- a/test/shared/lib/timestamp-utilties-tests.js
+++ b/test/shared/lib/timestamp-utilties-tests.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const assert = require('assert');
 
 const {

--- a/test/shared/lib/timestamp-utilties-tests.js
+++ b/test/shared/lib/timestamp-utilties-tests.js
@@ -1,6 +1,6 @@
 import assert from 'assert';
 
-const {
+import {
   roundUpTimestampToUtcDay,
   roundUpTimestampToUtcHour,
   roundUpTimestampToUtcMinute,
@@ -13,7 +13,7 @@ const {
   areTimestampsFromSameUtcHour,
   areTimestampsFromSameUtcMinute,
   areTimestampsFromSameUtcSecond,
-} = require('matrix-public-archive-shared/lib/timestamp-utilities');
+} from 'matrix-public-archive-shared/lib/timestamp-utilities';
 
 describe('timestamp-utilities', () => {
   describe('roundUpTimestampToUtcX', () => {

--- a/test/shared/lib/timestamp-utilties-tests.js
+++ b/test/shared/lib/timestamp-utilties-tests.js
@@ -13,7 +13,7 @@ import {
   areTimestampsFromSameUtcHour,
   areTimestampsFromSameUtcMinute,
   areTimestampsFromSameUtcSecond,
-} from 'matrix-public-archive-shared/lib/timestamp-utilities';
+} from 'matrix-public-archive-shared/lib/timestamp-utilities.js';
 
 describe('timestamp-utilities', () => {
   describe('roundUpTimestampToUtcX', () => {

--- a/test/test-utils/client-utils.js
+++ b/test/test-utils/client-utils.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const assert = require('assert');
 const urlJoin = require('url-join');
 const { fetchEndpointAsJson, fetchEndpoint } = require('../../server/lib/fetch-endpoint');

--- a/test/test-utils/client-utils.js
+++ b/test/test-utils/client-utils.js
@@ -419,7 +419,7 @@ async function uploadContent({ client, roomId, data, fileName, contentType }) {
   return mxcUri;
 }
 
-module.exports = {
+export {
   ensureUserRegistered,
   getTestClientForAs,
   getTestClientForHs,

--- a/test/test-utils/client-utils.js
+++ b/test/test-utils/client-utils.js
@@ -1,9 +1,9 @@
 import assert from 'assert';
 import urlJoin from 'url-join';
-import { fetchEndpointAsJson, fetchEndpoint } from '../../server/lib/fetch-endpoint';
-import getServerNameFromMatrixRoomIdOrAlias from '../../server/lib/matrix-utils/get-server-name-from-matrix-room-id-or-alias';
+import { fetchEndpointAsJson, fetchEndpoint } from '../../server/lib/fetch-endpoint.js';
+import getServerNameFromMatrixRoomIdOrAlias from '../../server/lib/matrix-utils/get-server-name-from-matrix-room-id-or-alias.js';
 
-import config from '../../server/lib/config';
+import config from '../../server/lib/config.js';
 const matrixAccessToken = config.get('matrixAccessToken');
 assert(matrixAccessToken);
 const testMatrixServerUrl1 = config.get('testMatrixServerUrl1');

--- a/test/test-utils/client-utils.js
+++ b/test/test-utils/client-utils.js
@@ -1,9 +1,9 @@
-const assert = require('assert');
-const urlJoin = require('url-join');
-const { fetchEndpointAsJson, fetchEndpoint } = require('../../server/lib/fetch-endpoint');
-const getServerNameFromMatrixRoomIdOrAlias = require('../../server/lib/matrix-utils/get-server-name-from-matrix-room-id-or-alias');
+import assert from 'assert';
+import urlJoin from 'url-join';
+import { fetchEndpointAsJson, fetchEndpoint } from '../../server/lib/fetch-endpoint';
+import getServerNameFromMatrixRoomIdOrAlias from '../../server/lib/matrix-utils/get-server-name-from-matrix-room-id-or-alias';
 
-const config = require('../../server/lib/config');
+import config from '../../server/lib/config';
 const matrixAccessToken = config.get('matrixAccessToken');
 assert(matrixAccessToken);
 const testMatrixServerUrl1 = config.get('testMatrixServerUrl1');

--- a/test/test-utils/parse-archive-url-for-room.js
+++ b/test/test-utils/parse-archive-url-for-room.js
@@ -24,4 +24,4 @@ function parseArchiveUrlForRoom(archiveUrlForRoom) {
   };
 }
 
-module.exports = parseArchiveUrlForRoom;
+export default parseArchiveUrlForRoom;

--- a/test/test-utils/parse-archive-url-for-room.js
+++ b/test/test-utils/parse-archive-url-for-room.js
@@ -1,6 +1,4 @@
-const {
-  VALID_ENTITY_DESCRIPTOR_TO_SIGIL_MAP,
-} = require('matrix-public-archive-shared/lib/reference-values');
+import { VALID_ENTITY_DESCRIPTOR_TO_SIGIL_MAP } from 'matrix-public-archive-shared/lib/reference-values';
 
 // http://archive.matrix.org/r/some-room:matrix.org/date/2022/11/16T23:59:59?at=$xxx
 function parseArchiveUrlForRoom(archiveUrlForRoom) {

--- a/test/test-utils/parse-archive-url-for-room.js
+++ b/test/test-utils/parse-archive-url-for-room.js
@@ -1,4 +1,4 @@
-import { VALID_ENTITY_DESCRIPTOR_TO_SIGIL_MAP } from 'matrix-public-archive-shared/lib/reference-values';
+import { VALID_ENTITY_DESCRIPTOR_TO_SIGIL_MAP } from 'matrix-public-archive-shared/lib/reference-values.js';
 
 // http://archive.matrix.org/r/some-room:matrix.org/date/2022/11/16T23:59:59?at=$xxx
 function parseArchiveUrlForRoom(archiveUrlForRoom) {

--- a/test/test-utils/parse-archive-url-for-room.js
+++ b/test/test-utils/parse-archive-url-for-room.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const {
   VALID_ENTITY_DESCRIPTOR_TO_SIGIL_MAP,
 } = require('matrix-public-archive-shared/lib/reference-values');

--- a/test/test-utils/parse-room-day-message-structure.js
+++ b/test/test-utils/parse-room-day-message-structure.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const assert = require('assert');
 
 function assertSequentialNumbersStartingFromOne(numbers) {

--- a/test/test-utils/parse-room-day-message-structure.js
+++ b/test/test-utils/parse-room-day-message-structure.js
@@ -1,4 +1,4 @@
-const assert = require('assert');
+import assert from 'assert';
 
 function assertSequentialNumbersStartingFromOne(numbers) {
   for (let i = 0; i < numbers.length - 1; i++) {

--- a/test/test-utils/parse-room-day-message-structure.js
+++ b/test/test-utils/parse-room-day-message-structure.js
@@ -196,4 +196,4 @@ function parseRoomDayMessageStructure(roomDayMessageStructureString) {
   };
 }
 
-module.exports = parseRoomDayMessageStructure;
+export default parseRoomDayMessageStructure;

--- a/test/test-utils/test-error.js
+++ b/test/test-utils/test-error.js
@@ -1,5 +1,3 @@
-'use strict';
-
 // This is used to distinguish between an `AssertionError` within our app code from an
 // `AssertionError` in the tests
 class TestError extends Error {

--- a/test/test-utils/test-error.js
+++ b/test/test-utils/test-error.js
@@ -8,4 +8,4 @@ class TestError extends Error {
   }
 }
 
-module.exports = TestError;
+export default TestError;


### PR DESCRIPTION
Refactor codebase from CommonJS to ESM

Spawning from the `gulp-rev` dependency in https://github.com/matrix-org/matrix-public-archive/pull/175 being ESM which kinda necessitates that we also switch over.

### Dev notes

See https://gist.github.com/sindresorhus/a39789f98801d908bbc7ff3ecc99d99c