### PR TITLE
Migrate from `eslint-plugin-node` to `eslint-plugin-n`

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -8,8 +8,7 @@
     "ecmaVersion": 2022,
     "sourceType": "script"
   },
-  "plugins": ["node"],
-  "extends": ["eslint:recommended", "prettier"],
+  "extends": ["eslint:recommended", "prettier", "plugin:n/recommended"],
   "rules": {
     "indent": "off",
     "comma-dangle": "off",
@@ -77,9 +76,8 @@
         }
       }
     ],
-    "node/no-missing-require": "error",
-    "node/no-missing-import": "error",
-    "node/no-unsupported-features/es-syntax": "error",
-    "node/no-unsupported-features/es-builtins": "error"
+    "n/no-process-exit": "off",
+    "n/no-unsupported-features/es-syntax": "error",
+    "n/no-unsupported-features/es-builtins": "error"
   }
 }

--- a/build-scripts/.eslintrc.json
+++ b/build-scripts/.eslintrc.json
@@ -1,0 +1,5 @@
+{
+  "rules": {
+    "n/no-unpublished-require": "off"
+  }
+}

--- a/client/js/.eslintrc.json
+++ b/client/js/.eslintrc.json
@@ -9,7 +9,7 @@
     "sourceType": "module"
   },
   "rules": {
-    "node/no-unsupported-features/es-syntax": "off",
-    "node/no-unsupported-features/es-builtins": "off"
+    "n/no-unsupported-features/es-syntax": "off",
+    "n/no-unsupported-features/es-builtins": "off"
   }
 }

--- a/client/js/entry-client-hydrogen.js
+++ b/client/js/entry-client-hydrogen.js
@@ -1,9 +1,6 @@
+// eslint-disable-next-line n/no-missing-import -- see https://github.com/eslint-community/eslint-plugin-n/issues/75
 import 'matrix-public-archive-shared/hydrogen-vm-render-script';
 
 // Assets
-// We have to disable no-missing-require lint because it doesn't take into
-// account `package.json`. `exports`, see
-// https://github.com/mysticatea/eslint-plugin-node/issues/255
-// eslint-disable-next-line node/no-missing-import
 import 'hydrogen-view-sdk/assets/theme-element-light.css';
 import '../css/styles.css';

--- a/client/js/entry-client-hydrogen.js
+++ b/client/js/entry-client-hydrogen.js
@@ -1,5 +1,4 @@
-// eslint-disable-next-line n/no-missing-import -- see https://github.com/eslint-community/eslint-plugin-n/issues/75
-import 'matrix-public-archive-shared/hydrogen-vm-render-script';
+import 'matrix-public-archive-shared/hydrogen-vm-render-script.js';
 
 // Assets
 import 'hydrogen-view-sdk/assets/theme-element-light.css';

--- a/client/js/entry-client-room-alias-hash-redirect.js
+++ b/client/js/entry-client-room-alias-hash-redirect.js
@@ -1,9 +1,6 @@
-// eslint-disable-next-line n/no-missing-import -- see https://github.com/eslint-community/eslint-plugin-n/issues/75
-import assert from 'matrix-public-archive-shared/lib/assert';
-// eslint-disable-next-line n/no-missing-import -- see https://github.com/eslint-community/eslint-plugin-n/issues/75
-import MatrixPublicArchiveURLCreator from 'matrix-public-archive-shared/lib/url-creator';
-// eslint-disable-next-line n/no-missing-import -- see https://github.com/eslint-community/eslint-plugin-n/issues/75
-import redirectIfRoomAliasInHash from 'matrix-public-archive-shared/lib/redirect-if-room-alias-in-hash';
+import assert from 'matrix-public-archive-shared/lib/assert.js';
+import MatrixPublicArchiveURLCreator from 'matrix-public-archive-shared/lib/url-creator.js';
+import redirectIfRoomAliasInHash from 'matrix-public-archive-shared/lib/redirect-if-room-alias-in-hash.js';
 
 // Assets
 import 'hydrogen-view-sdk/assets/theme-element-light.css';

--- a/client/js/entry-client-room-alias-hash-redirect.js
+++ b/client/js/entry-client-room-alias-hash-redirect.js
@@ -1,12 +1,11 @@
+// eslint-disable-next-line n/no-missing-import -- see https://github.com/eslint-community/eslint-plugin-n/issues/75
 import assert from 'matrix-public-archive-shared/lib/assert';
+// eslint-disable-next-line n/no-missing-import -- see https://github.com/eslint-community/eslint-plugin-n/issues/75
 import MatrixPublicArchiveURLCreator from 'matrix-public-archive-shared/lib/url-creator';
+// eslint-disable-next-line n/no-missing-import -- see https://github.com/eslint-community/eslint-plugin-n/issues/75
 import redirectIfRoomAliasInHash from 'matrix-public-archive-shared/lib/redirect-if-room-alias-in-hash';
 
 // Assets
-// We have to disable no-missing-require lint because it doesn't take into
-// account `package.json`. `exports`, see
-// https://github.com/mysticatea/eslint-plugin-node/issues/255
-// eslint-disable-next-line node/no-missing-import
 import 'hydrogen-view-sdk/assets/theme-element-light.css';
 import '../css/styles.css';
 

--- a/client/js/entry-client-room-directory.js
+++ b/client/js/entry-client-room-directory.js
@@ -1,10 +1,7 @@
+// eslint-disable-next-line n/no-missing-import -- see https://github.com/eslint-community/eslint-plugin-n/issues/75
 import 'matrix-public-archive-shared/room-directory-vm-render-script';
 
 // Assets
-// We have to disable no-missing-require lint because it doesn't take into
-// account `package.json`. `exports`, see
-// https://github.com/mysticatea/eslint-plugin-node/issues/255
-// eslint-disable-next-line node/no-missing-import
 import 'hydrogen-view-sdk/assets/theme-element-light.css';
 import '../css/styles.css';
 import '../css/room-directory.css';

--- a/client/js/entry-client-room-directory.js
+++ b/client/js/entry-client-room-directory.js
@@ -1,5 +1,4 @@
-// eslint-disable-next-line n/no-missing-import -- see https://github.com/eslint-community/eslint-plugin-n/issues/75
-import 'matrix-public-archive-shared/room-directory-vm-render-script';
+import 'matrix-public-archive-shared/room-directory-vm-render-script.js';
 
 // Assets
 import 'hydrogen-view-sdk/assets/theme-element-light.css';

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
         "chalk": "^4.1.2",
         "eslint": "^8.37.0",
         "eslint-config-prettier": "^8.8.0",
-        "eslint-plugin-node": "^11.1.0",
+        "eslint-plugin-n": "^15.7.0",
         "eslint-plugin-prettier": "^4.2.1",
         "merge-options": "^3.0.4",
         "mocha": "^9.2.1",
@@ -2748,6 +2748,30 @@
         "node": ">= 0.10.x"
       }
     },
+    "node_modules/builtins": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/builtins/-/builtins-5.0.1.tgz",
+      "integrity": "sha512-qwVpFEHNfhYJIzNRBvd2C1kyo6jz3ZSMPyyuR47OPdiKWlbYnZNyDWuyR175qDnAJLiCo5fBBqPb3RiXgWlkOQ==",
+      "dev": true,
+      "dependencies": {
+        "semver": "^7.0.0"
+      }
+    },
+    "node_modules/builtins/node_modules/semver": {
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.0.tgz",
+      "integrity": "sha512-+XC0AD/R7Q2mPSRuy2Id0+CGTZ98+8f+KvwirxOKIEyid+XSx6HbC63p+O4IndTHuX5Z+JxQ0TghCkO5Cg/2HA==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/bytes": {
       "version": "3.1.1",
       "license": "MIT",
@@ -3377,9 +3401,10 @@
       }
     },
     "node_modules/eslint-plugin-es": {
-      "version": "3.0.1",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-es/-/eslint-plugin-es-4.1.0.tgz",
+      "integrity": "sha512-GILhQTnjYE2WorX5Jyi5i4dz5ALWxBIdQECVQavL6s7cI76IZTDWleTHkxz/QT3kvcs2QlGHvKLYsSlPOlPXnQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "eslint-utils": "^2.0.0",
         "regexpp": "^3.0.0"
@@ -3396,8 +3421,9 @@
     },
     "node_modules/eslint-plugin-es/node_modules/eslint-utils": {
       "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.1.0.tgz",
+      "integrity": "sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "eslint-visitor-keys": "^1.1.0"
       },
@@ -3410,52 +3436,51 @@
     },
     "node_modules/eslint-plugin-es/node_modules/eslint-visitor-keys": {
       "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
+      "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
       "dev": true,
-      "license": "Apache-2.0",
       "engines": {
         "node": ">=4"
       }
     },
-    "node_modules/eslint-plugin-node": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-node/-/eslint-plugin-node-11.1.0.tgz",
-      "integrity": "sha512-oUwtPJ1W0SKD0Tr+wqu92c5xuCeQqB3hSCHasn/ZgjFdA9iDGNkNf2Zi9ztY7X+hNuMib23LNGRm6+uN+KLE3g==",
+    "node_modules/eslint-plugin-n": {
+      "version": "15.7.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-n/-/eslint-plugin-n-15.7.0.tgz",
+      "integrity": "sha512-jDex9s7D/Qial8AGVIHq4W7NswpUD5DPDL2RH8Lzd9EloWUuvUkHfv4FRLMipH5q2UtyurorBkPeNi1wVWNh3Q==",
       "dev": true,
       "dependencies": {
-        "eslint-plugin-es": "^3.0.0",
-        "eslint-utils": "^2.0.0",
+        "builtins": "^5.0.1",
+        "eslint-plugin-es": "^4.1.0",
+        "eslint-utils": "^3.0.0",
         "ignore": "^5.1.1",
-        "minimatch": "^3.0.4",
-        "resolve": "^1.10.1",
-        "semver": "^6.1.0"
+        "is-core-module": "^2.11.0",
+        "minimatch": "^3.1.2",
+        "resolve": "^1.22.1",
+        "semver": "^7.3.8"
       },
       "engines": {
-        "node": ">=8.10.0"
-      },
-      "peerDependencies": {
-        "eslint": ">=5.16.0"
-      }
-    },
-    "node_modules/eslint-plugin-node/node_modules/eslint-utils": {
-      "version": "2.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "eslint-visitor-keys": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=6"
+        "node": ">=12.22.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/mysticatea"
+      },
+      "peerDependencies": {
+        "eslint": ">=7.0.0"
       }
     },
-    "node_modules/eslint-plugin-node/node_modules/eslint-visitor-keys": {
-      "version": "1.3.0",
+    "node_modules/eslint-plugin-n/node_modules/semver": {
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.0.tgz",
+      "integrity": "sha512-+XC0AD/R7Q2mPSRuy2Id0+CGTZ98+8f+KvwirxOKIEyid+XSx6HbC63p+O4IndTHuX5Z+JxQ0TghCkO5Cg/2HA==",
       "dev": true,
-      "license": "Apache-2.0",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
       "engines": {
-        "node": ">=4"
+        "node": ">=10"
       }
     },
     "node_modules/eslint-plugin-prettier": {
@@ -3490,6 +3515,33 @@
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/eslint-utils": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
+      "integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
+      "dev": true,
+      "dependencies": {
+        "eslint-visitor-keys": "^2.0.0"
+      },
+      "engines": {
+        "node": "^10.0.0 || ^12.0.0 || >= 14.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mysticatea"
+      },
+      "peerDependencies": {
+        "eslint": ">=5"
+      }
+    },
+    "node_modules/eslint-utils/node_modules/eslint-visitor-keys": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
+      "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/eslint-visitor-keys": {
@@ -5444,8 +5496,9 @@
     },
     "node_modules/regexpp": {
       "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
+      "integrity": "sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=8"
       },
@@ -7995,6 +8048,26 @@
         "xtend": "^4.0.0"
       }
     },
+    "builtins": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/builtins/-/builtins-5.0.1.tgz",
+      "integrity": "sha512-qwVpFEHNfhYJIzNRBvd2C1kyo6jz3ZSMPyyuR47OPdiKWlbYnZNyDWuyR175qDnAJLiCo5fBBqPb3RiXgWlkOQ==",
+      "dev": true,
+      "requires": {
+        "semver": "^7.0.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "7.5.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.0.tgz",
+          "integrity": "sha512-+XC0AD/R7Q2mPSRuy2Id0+CGTZ98+8f+KvwirxOKIEyid+XSx6HbC63p+O4IndTHuX5Z+JxQ0TghCkO5Cg/2HA==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        }
+      }
+    },
     "bytes": {
       "version": "3.1.1"
     },
@@ -8421,7 +8494,9 @@
       "requires": {}
     },
     "eslint-plugin-es": {
-      "version": "3.0.1",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-es/-/eslint-plugin-es-4.1.0.tgz",
+      "integrity": "sha512-GILhQTnjYE2WorX5Jyi5i4dz5ALWxBIdQECVQavL6s7cI76IZTDWleTHkxz/QT3kvcs2QlGHvKLYsSlPOlPXnQ==",
       "dev": true,
       "requires": {
         "eslint-utils": "^2.0.0",
@@ -8430,6 +8505,8 @@
       "dependencies": {
         "eslint-utils": {
           "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.1.0.tgz",
+          "integrity": "sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==",
           "dev": true,
           "requires": {
             "eslint-visitor-keys": "^1.1.0"
@@ -8437,34 +8514,36 @@
         },
         "eslint-visitor-keys": {
           "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
+          "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
           "dev": true
         }
       }
     },
-    "eslint-plugin-node": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-node/-/eslint-plugin-node-11.1.0.tgz",
-      "integrity": "sha512-oUwtPJ1W0SKD0Tr+wqu92c5xuCeQqB3hSCHasn/ZgjFdA9iDGNkNf2Zi9ztY7X+hNuMib23LNGRm6+uN+KLE3g==",
+    "eslint-plugin-n": {
+      "version": "15.7.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-n/-/eslint-plugin-n-15.7.0.tgz",
+      "integrity": "sha512-jDex9s7D/Qial8AGVIHq4W7NswpUD5DPDL2RH8Lzd9EloWUuvUkHfv4FRLMipH5q2UtyurorBkPeNi1wVWNh3Q==",
       "dev": true,
       "requires": {
-        "eslint-plugin-es": "^3.0.0",
-        "eslint-utils": "^2.0.0",
+        "builtins": "^5.0.1",
+        "eslint-plugin-es": "^4.1.0",
+        "eslint-utils": "^3.0.0",
         "ignore": "^5.1.1",
-        "minimatch": "^3.0.4",
-        "resolve": "^1.10.1",
-        "semver": "^6.1.0"
+        "is-core-module": "^2.11.0",
+        "minimatch": "^3.1.2",
+        "resolve": "^1.22.1",
+        "semver": "^7.3.8"
       },
       "dependencies": {
-        "eslint-utils": {
-          "version": "2.1.0",
+        "semver": {
+          "version": "7.5.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.0.tgz",
+          "integrity": "sha512-+XC0AD/R7Q2mPSRuy2Id0+CGTZ98+8f+KvwirxOKIEyid+XSx6HbC63p+O4IndTHuX5Z+JxQ0TghCkO5Cg/2HA==",
           "dev": true,
           "requires": {
-            "eslint-visitor-keys": "^1.1.0"
+            "lru-cache": "^6.0.0"
           }
-        },
-        "eslint-visitor-keys": {
-          "version": "1.3.0",
-          "dev": true
         }
       }
     },
@@ -8485,6 +8564,23 @@
       "requires": {
         "esrecurse": "^4.3.0",
         "estraverse": "^5.2.0"
+      }
+    },
+    "eslint-utils": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
+      "integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
+      "dev": true,
+      "requires": {
+        "eslint-visitor-keys": "^2.0.0"
+      },
+      "dependencies": {
+        "eslint-visitor-keys": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
+          "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
+          "dev": true
+        }
       }
     },
     "eslint-visitor-keys": {
@@ -9689,6 +9785,8 @@
     },
     "regexpp": {
       "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
+      "integrity": "sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==",
       "dev": true
     },
     "registry-auth-token": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "chalk": "^4.1.2",
     "eslint": "^8.37.0",
     "eslint-config-prettier": "^8.8.0",
-    "eslint-plugin-node": "^11.1.0",
+    "eslint-plugin-n": "^15.7.0",
     "eslint-plugin-prettier": "^4.2.1",
     "merge-options": "^3.0.4",
     "mocha": "^9.2.1",

--- a/server/lib/get-dependencies-for-entry-point-name.js
+++ b/server/lib/get-dependencies-for-entry-point-name.js
@@ -11,7 +11,7 @@ function getManifest() {
     return _manifest;
   }
   // We have to disable this because it's built via the Vite client build.
-  // eslint-disable-next-line node/no-missing-require
+  // eslint-disable-next-line n/no-missing-require, n/no-unpublished-require
   _manifest = require('../../dist/manifest.json');
   return _manifest;
 }

--- a/server/lib/get-favicon-asset-urls.js
+++ b/server/lib/get-favicon-asset-urls.js
@@ -10,7 +10,7 @@ function getManifest() {
     return _manifest;
   }
   // We have to disable this because it's built via the Vite client build.
-  // eslint-disable-next-line node/no-missing-require
+  // eslint-disable-next-line n/no-missing-require, n/no-unpublished-require
   _manifest = require('../../dist/manifest.json');
   return _manifest;
 }

--- a/server/start-dev.js
+++ b/server/start-dev.js
@@ -3,6 +3,7 @@
 console.log('start-dev process.env.NODE_ENV', process.env.NODE_ENV);
 
 const path = require('path');
+// eslint-disable-next-line n/no-unpublished-require
 const nodemon = require('nodemon');
 
 const buildClient = require('../build-scripts/build-client');

--- a/test/.eslintrc.json
+++ b/test/.eslintrc.json
@@ -9,6 +9,7 @@
     "strict": [
       "error",
       "safe"
-    ]
+    ],
+    "n/no-unpublished-require": "off"
   }
 }


### PR DESCRIPTION
Migrate from `eslint-plugin-node` to `eslint-plugin-n`

Spawning originally from [.. ](https://github.com/matrix-org/matrix-public-archive/pull/177) where https://github.com/mysticatea/eslint-plugin-node/issues/255 was useful.

~~But we seem to be trading for a new problem -> https://github.com/eslint-community/eslint-plugin-n/issues/75~~