### PR TITLE
Only `require.resolve(...)` the path once

### DIFF
--- a/server/child-process-runner/run-in-child-process.js
+++ b/server/child-process-runner/run-in-child-process.js
@@ -24,6 +24,8 @@ if (!logOutputFromChildProcesses) {
   );
 }
 
+const resolvedChildForkScriptPath = require.resolve('./child-fork-script');
+
 function assembleErrorAfterChildExitsWithErrors(exitCode, childErrors) {
   assert(childErrors);
 
@@ -72,7 +74,7 @@ async function runInChildProcess(modulePath, runArguments, { timeout }) {
     // We use a child_process because we want to be able to exit the process
     // after we receive the results. We use `fork` instead of `exec`/`spawn` so
     // that we can pass a module instead of running a command.
-    const child = fork(require.resolve('./child-fork-script'), [modulePath], {
+    const child = fork(resolvedChildForkScriptPath, [modulePath], {
       signal,
       // Default to silencing logs from the child process. We already have
       // proper instrumentation of any errors that might occur.

--- a/server/hydrogen-render/render-hydrogen-to-string.js
+++ b/server/hydrogen-render/render-hydrogen-to-string.js
@@ -10,6 +10,10 @@ const assert = require('assert');
 const RethrownError = require('../lib/rethrown-error');
 const runInChildProcess = require('../child-process-runner/run-in-child-process');
 
+const resolvedREnderHydrogenToStringUnsafeScriptPath = require.resolve(
+  './render-hydrogen-to-string-unsafe'
+);
+
 // The render should be fast. If it's taking more than 5 seconds, something has
 // gone really wrong.
 const RENDER_TIMEOUT = 5000;
@@ -40,7 +44,7 @@ async function renderHydrogenToString(renderOptions) {
     // we receive the SSR results. We don't want Hydrogen to keep running after we
     // get our initial rendered HTML.
     const hydrogenHtmlOutput = await runInChildProcess(
-      require.resolve('./render-hydrogen-to-string-unsafe'),
+      resolvedREnderHydrogenToStringUnsafeScriptPath,
       renderOptions,
       {
         timeout: RENDER_TIMEOUT,

--- a/server/hydrogen-render/render-hydrogen-to-string.js
+++ b/server/hydrogen-render/render-hydrogen-to-string.js
@@ -10,7 +10,7 @@ const assert = require('assert');
 const RethrownError = require('../lib/rethrown-error');
 const runInChildProcess = require('../child-process-runner/run-in-child-process');
 
-const resolvedREnderHydrogenToStringUnsafeScriptPath = require.resolve(
+const resolvedRenderHydrogenToStringUnsafeScriptPath = require.resolve(
   './render-hydrogen-to-string-unsafe'
 );
 
@@ -44,7 +44,7 @@ async function renderHydrogenToString(renderOptions) {
     // we receive the SSR results. We don't want Hydrogen to keep running after we
     // get our initial rendered HTML.
     const hydrogenHtmlOutput = await runInChildProcess(
-      resolvedREnderHydrogenToStringUnsafeScriptPath,
+      resolvedRenderHydrogenToStringUnsafeScriptPath,
       renderOptions,
       {
         timeout: RENDER_TIMEOUT,


### PR DESCRIPTION
Only `require.resolve(...)` the path once.

Perhaps an early optimization or not even needed but doesn't seem wise to keep pulling this over and over (best case it's cached).