### PR TITLE
Fix scripts not loading from the production ready build PR

### DIFF
--- a/build-scripts/vite.config.js
+++ b/build-scripts/vite.config.js
@@ -20,11 +20,17 @@ module.exports = defineConfig({
     // splitVendorChunkPlugin(),
   ],
 
-  //root: './',
-  //base: './',
-  // optimizeDeps: {
-  //   include: ['matrix-public-archive-shared'],
-  // },
+  optimizeDeps: {
+    include: [
+      // CommonJS only gets supported when it's pre-bundled and we `require('hydrogen-view-sdk')`
+      'hydrogen-view-sdk',
+
+      // This doesn't seem to be necessary for the this package to work (ref
+      // https://vitejs.dev/guide/dep-pre-bundling.html#monorepos-and-linked-dependencies)
+      //
+      //'matrix-public-archive-shared'
+    ],
+  },
   resolve: {
     alias: {
       // The `file:` packages don't seem resolve correctly so let's add an alias as well
@@ -72,9 +78,11 @@ module.exports = defineConfig({
     // Copy things like the version files from `public/` to `dist/`
     copyPublicDir: true,
 
-    // Fix `Error: 'default' is not exported by ...` when importing CommonJS files, see
-    // https://github.com/vitejs/vite/issues/2679 and docs:
-    // https://vitejs.dev/guide/dep-pre-bundling.html#monorepos-and-linked-dependencies
-    commonjsOptions: { include: [/shared/] },
+    commonjsOptions: {
+      // Fix `Error: 'default' is not exported by ...` when importing CommonJS files, see
+      // https://github.com/vitejs/vite/issues/2679 and docs:
+      // https://vitejs.dev/guide/dep-pre-bundling.html#monorepos-and-linked-dependencies
+      include: [/shared\//, /hydrogen-view-sdk/, /another-json/, /base64-arraybuffer/, /off-color/],
+    },
   },
 });

--- a/build-scripts/vite.config.js
+++ b/build-scripts/vite.config.js
@@ -82,20 +82,9 @@ module.exports = defineConfig({
         // https://vitejs.dev/guide/dep-pre-bundling.html#monorepos-and-linked-dependencies
         /shared\//,
 
-        // Our own depdencies that are CommonJS. Having to maintain this list is very icky
-        //
-        // TODO: How can we improve this? Related to the below list as well
-        /url-join/,
-
-        // Fix CommonJS problems with `require('hydrogen-view-sdk')` otherwise we see
-        // problems like "ReferenceError: exports is not defined" when it tries to run
-        // in the browser.
-        //
-        // TODO: Could we read the deps from the Hydrogen package.json?
-        /hydrogen-view-sdk/,
-        /another-json/,
-        /base64-arraybuffer/,
-        /off-color/,
+        // Make all of our `require()` CommonJS calls compatible in the ESM client build.
+        // See https://vitejs.dev/guide/dep-pre-bundling.html#monorepos-and-linked-dependencies
+        /node_modules/,
       ],
     },
   },

--- a/build-scripts/vite.config.js
+++ b/build-scripts/vite.config.js
@@ -22,9 +22,6 @@ module.exports = defineConfig({
 
   optimizeDeps: {
     include: [
-      // CommonJS only gets supported when it's pre-bundled and we `require('hydrogen-view-sdk')`
-      'hydrogen-view-sdk',
-
       // This doesn't seem to be necessary for the this package to work (ref
       // https://vitejs.dev/guide/dep-pre-bundling.html#monorepos-and-linked-dependencies)
       //
@@ -79,10 +76,27 @@ module.exports = defineConfig({
     copyPublicDir: true,
 
     commonjsOptions: {
-      // Fix `Error: 'default' is not exported by ...` when importing CommonJS files, see
-      // https://github.com/vitejs/vite/issues/2679 and docs:
-      // https://vitejs.dev/guide/dep-pre-bundling.html#monorepos-and-linked-dependencies
-      include: [/shared\//, /hydrogen-view-sdk/, /another-json/, /base64-arraybuffer/, /off-color/],
+      include: [
+        // Fix `Error: 'default' is not exported by ...` when importing CommonJS files, see
+        // https://github.com/vitejs/vite/issues/2679 and docs:
+        // https://vitejs.dev/guide/dep-pre-bundling.html#monorepos-and-linked-dependencies
+        /shared\//,
+
+        // Our own depdencies that are CommonJS. Having to maintain this list is very icky
+        //
+        // TODO: How can we improve this? Related to the below list as well
+        /url-join/,
+
+        // Fix CommonJS problems with `require('hydrogen-view-sdk')` otherwise we see
+        // problems like "ReferenceError: exports is not defined" when it tries to run
+        // in the browser.
+        //
+        // TODO: Could we read the deps from the Hydrogen package.json?
+        /hydrogen-view-sdk/,
+        /another-json/,
+        /base64-arraybuffer/,
+        /off-color/,
+      ],
     },
   },
 });

--- a/server/hydrogen-render/render-page-html.js
+++ b/server/hydrogen-render/render-page-html.js
@@ -88,7 +88,7 @@ if (atEventId) {
           ${scripts
             .map(
               (scriptUrl) =>
-                `<script type="text/javascript" src="${scriptUrl}" nonce="${pageOptions.cspNonce}"></script>`
+                `<script type="module" src="${scriptUrl}" nonce="${pageOptions.cspNonce}"></script>`
             )
             .join('\n')}
           <script type="text/javascript" nonce="${pageOptions.cspNonce}">

--- a/server/lib/get-dependencies-for-entry-point-name.js
+++ b/server/lib/get-dependencies-for-entry-point-name.js
@@ -33,16 +33,19 @@ function recurseManifestEntryName(entryName) {
   const manifest = getManifest();
   const entry = manifest[entryName];
 
+  const entryFilePath = path.join('/', entry.file);
+
   // css
   const styles = [];
   // imports
-  const scripts = [];
+  const scripts = [entryFilePath];
   // imports, dynamicImports
-  const preloadScripts = [];
+  const preloadScripts = [entryFilePath];
 
   for (const importName of entry.imports || []) {
-    scripts.push(path.join('/', importName));
-    preloadScripts.push(path.join('/', importName));
+    const importFilePath = path.join('/', manifest[importName].file);
+    scripts.push(importFilePath);
+    preloadScripts.push(importFilePath);
 
     const {
       styles: moreStyles,
@@ -56,7 +59,8 @@ function recurseManifestEntryName(entryName) {
   }
 
   for (const dynamicImportName of entry.dynamicImports || []) {
-    preloadScripts.push(path.join('/', dynamicImportName));
+    const dynamicImportFilePath = path.join('/', manifest[dynamicImportName].file);
+    preloadScripts.push(dynamicImportFilePath);
 
     const {
       styles: moreStyles,

--- a/server/lib/get-dependencies-for-entry-point-name.js
+++ b/server/lib/get-dependencies-for-entry-point-name.js
@@ -10,6 +10,7 @@ function getManifest() {
   if (_manifest) {
     return _manifest;
   }
+
   // We have to disable this because it's built via the Vite client build.
   // eslint-disable-next-line n/no-missing-require, n/no-unpublished-require
   _manifest = require('../../dist/manifest.json');

--- a/server/start-dev.js
+++ b/server/start-dev.js
@@ -13,9 +13,7 @@ buildClient({
   build: {
     // Rebuild when we see changes
     // https://rollupjs.org/guide/en/#watch-options
-    watch: {
-      exclude: ['server/**/*'],
-    },
+    watch: true,
   },
 });
 
@@ -45,14 +43,7 @@ nodemon({
   script: path.join(__dirname, './server.js'),
   ext: 'js json',
   ignoreRoot: ['.git'],
-  ignore: [
-    // Ignore everything except changes to the manifest.json because we read it on the
-    // server and we should always have an up to date copy.
-    //
-    // TODO: I don't think this actually works. When `manifest.json` updates, the server
-    // should restart.
-    path.join(__dirname, '../dist/**/!(manifest.json)'),
-  ],
+  ignore: [path.join(__dirname, '../dist/*')],
   args,
   nodeArgs,
 });

--- a/server/start-dev.js
+++ b/server/start-dev.js
@@ -13,7 +13,9 @@ buildClient({
   build: {
     // Rebuild when we see changes
     // https://rollupjs.org/guide/en/#watch-options
-    watch: true,
+    watch: {
+      exclude: ['server/**/*'],
+    },
   },
 });
 
@@ -43,7 +45,14 @@ nodemon({
   script: path.join(__dirname, './server.js'),
   ext: 'js json',
   ignoreRoot: ['.git'],
-  ignore: [path.join(__dirname, '../dist/*')],
+  ignore: [
+    // Ignore everything except changes to the manifest.json because we read it on the
+    // server and we should always have an up to date copy.
+    //
+    // TODO: I don't think this actually works. When `manifest.json` updates, the server
+    // should restart.
+    path.join(__dirname, '../dist/**/!(manifest.json)'),
+  ],
   args,
   nodeArgs,
 });


### PR DESCRIPTION
Fix scripts not loading from the [production ready build PR](https://github.com/matrix-org/matrix-public-archive/pull/175).

We don't have tests for the client-side UI interactions and I didn't properly test myself since the page looked good.


## Dev notes


#### Using wrong asset paths.

We need to use the `file` part from the `manifest.json` and prepend `/` so the path always starts from the root.


#### `<script type="module">` problems

Change from `<script type="text/javascript"> to `<script type="module">`



#### Hydrogen using CommonJS version

```
Uncaught ReferenceError: exports is not defined
    at hydrogen.cjs.js:34:25
```

 - `build.commonjsOptions.transformMixedEsModules`
    - https://vitejs.dev/config/build-options.html#build-commonjsoptions
    - https://github.com/rollup/plugins/tree/master/packages/commonjs#transformmixedesmodules
 - `optimizeDeps.include`: https://vitejs.dev/guide/dep-pre-bundling.html
 - `build.commonjsOptions.include`
 - https://github.com/vitejs/vite/issues/2579


#### `crossorigin` problems


```
A preload for 'foo' is found, but is not used because the request credentials mode does not match. Consider taking a look at crossorigin attribute.
```

I see a way to add `crossorigin` to a `<link rel="preload">` tag but we're using `Link` headers 🤔

 - https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/crossorigin
 - https://github.com/matrix-org/matrix-authentication-service/blob/7003dae354acb96761c81e457eafef23b7e83ce3/crates/spa/src/vite.rs#L85