### PR TITLE
Make sure to restart the server after Vite `manifest.json` changes

### DIFF
--- a/server/start-dev.js
+++ b/server/start-dev.js
@@ -13,9 +13,7 @@ buildClient({
   build: {
     // Rebuild when we see changes
     // https://rollupjs.org/guide/en/#watch-options
-    watch: {
-      exclude: ['server/**/*'],
-    },
+    watch: true,
   },
 });
 

--- a/server/start-dev.js
+++ b/server/start-dev.js
@@ -13,7 +13,9 @@ buildClient({
   build: {
     // Rebuild when we see changes
     // https://rollupjs.org/guide/en/#watch-options
-    watch: true,
+    watch: {
+      exclude: ['server/**/*'],
+    },
   },
 });
 
@@ -43,7 +45,14 @@ nodemon({
   script: path.join(__dirname, './server.js'),
   ext: 'js json',
   ignoreRoot: ['.git'],
-  ignore: [path.join(__dirname, '../dist/*')],
+  ignore: [
+    // Ignore everything in `dist/` except changes to the `manifest.json` because we read it on the
+    // server and we should always have an up to date copy.
+    //
+    // TODO: I don't think this actually works. When `manifest.json` updates, the server
+    // should restart.
+    path.join(__dirname, '../dist/**/!(manifest.json)'),
+  ],
   args,
   nodeArgs,
 });

--- a/server/start-dev.js
+++ b/server/start-dev.js
@@ -2,6 +2,11 @@
 
 console.log('start-dev process.env.NODE_ENV', process.env.NODE_ENV);
 
+// Using the `posix` version to always use forward slashes in the glob patterns for
+// the nodemon `ignore` option. It wasn't matching properly otherwise.
+// Ex.
+// Before: `.\dist\**\!(manifest.json)`
+// After: `dist/**/!(manifest.json)`
 const path = require('path').posix;
 // eslint-disable-next-line n/no-unpublished-require
 const nodemon = require('nodemon');

--- a/server/start-dev.js
+++ b/server/start-dev.js
@@ -2,7 +2,7 @@
 
 console.log('start-dev process.env.NODE_ENV', process.env.NODE_ENV);
 
-const path = require('path');
+const path = require('path').posix;
 // eslint-disable-next-line n/no-unpublished-require
 const nodemon = require('nodemon');
 
@@ -42,17 +42,20 @@ if (process.argv.logOutputFromChildProcesses) {
 nodemon({
   script: path.join(__dirname, './server.js'),
   ext: 'js json',
+  // We override `ignoreRoot` which includes `node_modules` by default because we we
+  // want to watch `node_modules` for changes whenever we symlink `hydrogen-view-sdk`
+  // in, see
+  // https://github.com/remy/nodemon/blob/master/faq.md#overriding-the-underlying-default-ignore-rules
   ignoreRoot: ['.git'],
   ignore: [
-    // Ignore everything in `dist/` except changes to the `manifest.json` because we read it on the
-    // server and we should always have an up to date copy.
-    //
-    // TODO: I don't think this actually works. When `manifest.json` updates, the server
-    // should restart.
+    // Ignore everything in `dist/` except changes to the `manifest.json` because we
+    // read it on the server and we should always have an up to date copy.
     path.join(__dirname, '../dist/**/!(manifest.json)'),
   ],
   args,
   nodeArgs,
+  // Helpful for debugging why things aren't watched or ignored
+  //verbose: true,
 });
 
 nodemon
@@ -70,7 +73,7 @@ nodemon
     console.log('Nodemon: script crashed for some reason');
   })
   // .on('watching', (file) => {
-  //   console.log('watching');
+  //   console.log('watching', file);
   // })
   .on('log', function (data) {
     console.log(`Nodemon logs: ${data.type}: ${data.message}`);


### PR DESCRIPTION
Make sure to restart the server after Vite `manifest.json` changes so it can pick up the latest and serve pages correctly.