### PR TITLE
Make sure we still convert from CommonJS to ESM even when symlinking `hydrogen-view-sdk` locally

### DIFF
--- a/build-scripts/vite.config.js
+++ b/build-scripts/vite.config.js
@@ -34,11 +34,11 @@ module.exports = defineConfig({
       // See https://css-tricks.com/adding-vite-to-your-existing-web-app/#aa-aliases
       'matrix-public-archive-shared': path.resolve(__dirname, '../shared'),
     },
-    // This will make sure Rollup matches the original file path (i.e. the path without
-    // following symlinks) instead of the real file path (i.e. the path after following
-    // symlinks). This is useful when symlinking `hydrogen-view-sdk`, so it still
-    // matches our `/node_modules/` pattern in the `build.commonjsOptions.include`
-    // config below and gets converted to CommonJS to ESM as expected.
+    // This will make sure Vite/Rollup matches the original file path (i.e. the path
+    // without following symlinks) instead of the real file path (i.e. the path after
+    // following symlinks). This is useful when symlinking `hydrogen-view-sdk`, so it
+    // still matches our `/node_modules/` pattern in the `build.commonjsOptions.include`
+    // config below and gets converted from CommonJS to ESM as expected.
     preserveSymlinks: true,
   },
   build: {

--- a/build-scripts/vite.config.js
+++ b/build-scripts/vite.config.js
@@ -34,6 +34,12 @@ module.exports = defineConfig({
       // See https://css-tricks.com/adding-vite-to-your-existing-web-app/#aa-aliases
       'matrix-public-archive-shared': path.resolve(__dirname, '../shared'),
     },
+    // This will make sure Rollup matches the original file path (i.e. the path without
+    // following symlinks) instead of the real file path (i.e. the path after following
+    // symlinks). This is useful when symlinking `hydrogen-view-sdk`, so it still
+    // matches our `/node_modules/` pattern in the `build.commonjsOptions.include`
+    // config below and gets converted to CommonJS to ESM as expected.
+    preserveSymlinks: true,
   },
   build: {
     outDir: './dist',


### PR DESCRIPTION
Make sure we still convert from CommonJS to ESM even when symlinking `hydrogen-view-sdk` locally


### Dev notes

 - https://github.com/rollup/plugins/tree/master/packages/commonjs#usage-with-symlinks
 - https://vitejs.dev/config/shared-options.html#resolve-preservesymlinks
 - https://github.com/vitejs/vite/issues/2405 -> https://github.com/vitejs/vite/pull/4708/files
 - https://rollupjs.org/configuration-options/#preservesymlinks