### PR TITLE
Update Hydrogen SDK dependency `0.26.0-scratch` - 2023-04-26

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "dompurify": "^2.3.9",
         "escape-string-regexp": "^4.0.0",
         "express": "^4.17.2",
-        "hydrogen-view-sdk": "npm:@mlm/hydrogen-view-sdk@^0.25.0-scratch",
+        "hydrogen-view-sdk": "npm:@mlm/hydrogen-view-sdk@^0.26.0-scratch",
         "json5": "^2.2.1",
         "linkedom": "^0.14.17",
         "matrix-public-archive-shared": "file:./shared/",
@@ -620,9 +620,9 @@
       "dev": true
     },
     "node_modules/@matrix-org/olm": {
-      "version": "3.2.8",
-      "resolved": "https://gitlab.matrix.org/api/v4/projects/27/packages/npm/@matrix-org/olm/-/@matrix-org/olm-3.2.8.tgz",
-      "integrity": "sha512-yCJzEYY2aG1z+7nxKYZC4DFYwQO/5iG019qgotJhauYJRhEG9gLrKTvXO6lRHS8TjnZzsZFZyO/hQUlI4Dryig==",
+      "version": "3.2.14",
+      "resolved": "https://gitlab.matrix.org/api/v4/projects/27/packages/npm/@matrix-org/olm/-/@matrix-org/olm-3.2.14.tgz",
+      "integrity": "sha512-Yz8X5+R1PL0RwJNjuH4r9WgWgXHX5v4NB093baUUE3Wh1INHEminESeur6FtIfQhVRQd8UZ9HRBh+Rd2nkNFGQ==",
       "license": "Apache-2.0"
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -4146,11 +4146,11 @@
     },
     "node_modules/hydrogen-view-sdk": {
       "name": "@mlm/hydrogen-view-sdk",
-      "version": "0.25.0-scratch",
-      "resolved": "https://registry.npmjs.org/@mlm/hydrogen-view-sdk/-/hydrogen-view-sdk-0.25.0-scratch.tgz",
-      "integrity": "sha512-FgSBCgNbVe/jiy6khdY8ZtbcZ/CRPc1cDPNZM0skUWTnuXzDtzPUQ2dW45yOO951gd+GS01TPhpibjowEOWrow==",
+      "version": "0.26.0-scratch",
+      "resolved": "https://registry.npmjs.org/@mlm/hydrogen-view-sdk/-/hydrogen-view-sdk-0.26.0-scratch.tgz",
+      "integrity": "sha512-rgFCbaI7P5eeaxsTYzfDZ1vII2Sb6uVgK7kut3rqAMPrqnc3Y7AVuY/TUrsBTaviIHJ/OH9suAHISkx9kE29ZA==",
       "dependencies": {
-        "@matrix-org/olm": "https://gitlab.matrix.org/api/v4/projects/27/packages/npm/@matrix-org/olm/-/@matrix-org/olm-3.2.8.tgz",
+        "@matrix-org/olm": "https://gitlab.matrix.org/api/v4/projects/27/packages/npm/@matrix-org/olm/-/@matrix-org/olm-3.2.14.tgz",
         "another-json": "^0.2.0",
         "base64-arraybuffer": "^0.2.0",
         "dompurify": "^2.3.0",
@@ -6684,8 +6684,8 @@
       "dev": true
     },
     "@matrix-org/olm": {
-      "version": "https://gitlab.matrix.org/api/v4/projects/27/packages/npm/@matrix-org/olm/-/@matrix-org/olm-3.2.8.tgz",
-      "integrity": "sha512-yCJzEYY2aG1z+7nxKYZC4DFYwQO/5iG019qgotJhauYJRhEG9gLrKTvXO6lRHS8TjnZzsZFZyO/hQUlI4Dryig=="
+      "version": "https://gitlab.matrix.org/api/v4/projects/27/packages/npm/@matrix-org/olm/-/@matrix-org/olm-3.2.14.tgz",
+      "integrity": "sha512-Yz8X5+R1PL0RwJNjuH4r9WgWgXHX5v4NB093baUUE3Wh1INHEminESeur6FtIfQhVRQd8UZ9HRBh+Rd2nkNFGQ=="
     },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -8975,11 +8975,11 @@
       }
     },
     "hydrogen-view-sdk": {
-      "version": "npm:@mlm/hydrogen-view-sdk@0.25.0-scratch",
-      "resolved": "https://registry.npmjs.org/@mlm/hydrogen-view-sdk/-/hydrogen-view-sdk-0.25.0-scratch.tgz",
-      "integrity": "sha512-FgSBCgNbVe/jiy6khdY8ZtbcZ/CRPc1cDPNZM0skUWTnuXzDtzPUQ2dW45yOO951gd+GS01TPhpibjowEOWrow==",
+      "version": "npm:@mlm/hydrogen-view-sdk@0.26.0-scratch",
+      "resolved": "https://registry.npmjs.org/@mlm/hydrogen-view-sdk/-/hydrogen-view-sdk-0.26.0-scratch.tgz",
+      "integrity": "sha512-rgFCbaI7P5eeaxsTYzfDZ1vII2Sb6uVgK7kut3rqAMPrqnc3Y7AVuY/TUrsBTaviIHJ/OH9suAHISkx9kE29ZA==",
       "requires": {
-        "@matrix-org/olm": "https://gitlab.matrix.org/api/v4/projects/27/packages/npm/@matrix-org/olm/-/@matrix-org/olm-3.2.8.tgz",
+        "@matrix-org/olm": "https://gitlab.matrix.org/api/v4/projects/27/packages/npm/@matrix-org/olm/-/@matrix-org/olm-3.2.14.tgz",
         "another-json": "^0.2.0",
         "base64-arraybuffer": "^0.2.0",
         "dompurify": "^2.3.0",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "dompurify": "^2.3.9",
     "escape-string-regexp": "^4.0.0",
     "express": "^4.17.2",
-    "hydrogen-view-sdk": "npm:@mlm/hydrogen-view-sdk@^0.25.0-scratch",
+    "hydrogen-view-sdk": "npm:@mlm/hydrogen-view-sdk@^0.26.0-scratch",
     "json5": "^2.2.1",
     "linkedom": "^0.14.17",
     "matrix-public-archive-shared": "file:./shared/",

--- a/shared/hydrogen-vm-render-script.js
+++ b/shared/hydrogen-vm-render-script.js
@@ -64,7 +64,10 @@ async function mountHydrogen() {
   const navigation = createNavigation();
   platform.setNavigation(navigation);
 
-  const archiveHistory = new ArchiveHistory(`#/session/123/room/${roomData.id}`);
+  const archiveHistory = new ArchiveHistory(
+    // We just have to match what Hydrogen is doing here.
+    `#/session/123/room/${encodeURIComponent(roomData.id)}`
+  );
   const urlRouter = createRouter({
     navigation: navigation,
     // We use our own history because we want the hash to be relative to the


### PR DESCRIPTION
Update with latest Hydrogen changes `0.26.0-scratch` - 2023-04-26

Spawning from https://github.com/matrix-org/matrix-public-archive/pull/187#discussion_r1177644014


Of note:

 - Adds date headers, https://github.com/vector-im/hydrogen-web/pull/938
 - Add "Copy matrix.to permalink" message action, https://github.com/vector-im/hydrogen-web/pull/921
 - Removes `?v=3.13` query parameters from Inter font references in CSS, https://github.com/vector-im/hydrogen-web/pull/961
    - This is what we need to solve https://github.com/matrix-org/matrix-public-archive/pull/187#discussion_r1177638781

## Todo

 - [x] Make release from our [scratch branch](https://github.com/vector-im/hydrogen-web/pull/653) -> `@mlm/hydrogen-view-sdk@0.26.0-scratch`
    ```
    cd hydrogen-web
    yarn build:sdk
    cd target
    Edit `target/package.json` to `@mlm/hydrogen-view-sdk@^0.26.0-scratch`
    npm publish
    ```
 - [x] Update the `hydrogen-view-sdk` dependency version in this PR (edit `package.json` in our project and `npm install`)