### PR TITLE
Cache derived info from the `manifest.json`

### DIFF
--- a/server/hydrogen-render/render-page-html.js
+++ b/server/hydrogen-render/render-page-html.js
@@ -8,8 +8,6 @@ const safeJson = require('../lib/safe-json');
 const getDependenciesForEntryPointName = require('../lib/get-dependencies-for-entry-point-name');
 const getFaviconAssetUrls = require('../lib/get-favicon-asset-urls');
 
-const faviconMap = getFaviconAssetUrls();
-
 async function renderPageHtml({
   pageOptions,
   // Make sure you sanitize this before passing it to us
@@ -39,6 +37,7 @@ async function renderPageHtml({
     maybeNoIndexHtml = `<meta name="robots" content="noindex, nofollow" />`;
   }
 
+  const faviconMap = getFaviconAssetUrls();
   const pageHtml = `
       <!doctype html>
       <html lang="en">

--- a/server/lib/get-dependencies-for-entry-point-name.js
+++ b/server/lib/get-dependencies-for-entry-point-name.js
@@ -128,8 +128,14 @@ function recurseManifestEntryName(entryName) {
 }
 
 // Look through the Vite manifest.json and return the dependencies for a given entry
+const entryPointNameToDependencies = new Map();
 function getDependenciesForEntryPointName(entryPointName) {
   assert(entryPointName);
+
+  // Try our cache shortcut first
+  if (entryPointNameToDependencies.has(entryPointName)) {
+    return entryPointNameToDependencies.get(entryPointName);
+  }
 
   // Lazy-load the manifest so we only require it on first call hopefully after the Vite
   // client build completes. `require(...)` calls are cached so it should be fine to
@@ -152,7 +158,7 @@ function getDependenciesForEntryPointName(entryPointName) {
   const { styles, fonts, images, scripts, preloadScripts } =
     recurseManifestEntryName(entryPointName);
 
-  return {
+  const deduplicatedDependencies = {
     // De-duplicate assets
     styles: Array.from(new Set(styles)),
     fonts: Array.from(new Set(fonts)),
@@ -160,6 +166,9 @@ function getDependenciesForEntryPointName(entryPointName) {
     scripts: Array.from(new Set(scripts)),
     preloadScripts: Array.from(new Set(preloadScripts)),
   };
+
+  entryPointNameToDependencies.set(entryPointName, deduplicatedDependencies);
+  return deduplicatedDependencies;
 }
 
 module.exports = getDependenciesForEntryPointName;

--- a/server/lib/get-dependencies-for-entry-point-name.js
+++ b/server/lib/get-dependencies-for-entry-point-name.js
@@ -3,27 +3,21 @@
 const assert = require('assert');
 const path = require('path').posix;
 
-// Lazy-load the manifest so we only require it on first call hopefully after the Vite
-// client build completes.
-let _manifest;
-function getManifest() {
-  if (_manifest) {
-    return _manifest;
-  }
-
-  // We have to disable this because it's built via the Vite client build.
-  // eslint-disable-next-line n/no-missing-require, n/no-unpublished-require
-  _manifest = require('../../dist/manifest.json');
-  return _manifest;
-}
-
 let _entryPoints;
 function getEntryPoints() {
+  // Probably not that much overhead but only calculate this once
   if (_entryPoints) {
     return _entryPoints;
   }
 
-  const manifest = getManifest();
+  // Lazy-load the manifest so we only require it on first call hopefully after the Vite
+  // client build completes. `require(...)` calls are cached so it should be fine to
+  // look this up over and over.
+  //
+  // We have to disable this because it's built via the Vite client build.
+  // eslint-disable-next-line n/no-missing-require, n/no-unpublished-require
+  const manifest = require('../../dist/manifest.json');
+
   _entryPoints = Object.keys(manifest).filter((name) => {
     return manifest[name].isEntry;
   });
@@ -32,9 +26,15 @@ function getEntryPoints() {
 
 // eslint-disable-next-line max-statements
 function recurseManifestEntryName(entryName) {
-  const manifest = getManifest();
-  const entry = manifest[entryName];
+  // Lazy-load the manifest so we only require it on first call hopefully after the Vite
+  // client build completes. `require(...)` calls are cached so it should be fine to
+  // look this up over and over.
+  //
+  // We have to disable this because it's built via the Vite client build.
+  // eslint-disable-next-line n/no-missing-require, n/no-unpublished-require
+  const manifest = require('../../dist/manifest.json');
 
+  const entry = manifest[entryName];
   const entryFilePath = path.join('/', entry.file);
 
   // css
@@ -130,7 +130,14 @@ function recurseManifestEntryName(entryName) {
 // Look through the Vite manifest.json and return the dependencies for a given entry
 function getDependenciesForEntryPointName(entryPointName) {
   assert(entryPointName);
-  const manifest = getManifest();
+
+  // Lazy-load the manifest so we only require it on first call hopefully after the Vite
+  // client build completes. `require(...)` calls are cached so it should be fine to
+  // look this up over and over.
+  //
+  // We have to disable this because it's built via the Vite client build.
+  // eslint-disable-next-line n/no-missing-require, n/no-unpublished-require
+  const manifest = require('../../dist/manifest.json');
 
   const entry = manifest[entryPointName];
   assert(

--- a/server/lib/get-favicon-asset-urls.js
+++ b/server/lib/get-favicon-asset-urls.js
@@ -2,28 +2,29 @@
 
 const path = require('path').posix;
 
-// Lazy-load the manifest so we only require it on first call hopefully after the Vite
-// client build completes.
-let _manifest;
-function getManifest() {
-  if (_manifest) {
-    return _manifest;
+let _faviconAssetUrls;
+function getFaviconAssetUrls() {
+  // Probably not that much overhead but only calculate this once
+  if (_faviconAssetUrls) {
+    return _faviconAssetUrls;
   }
+
+  // Lazy-load the manifest so we only require it on first call hopefully after the Vite
+  // client build completes. `require(...)` calls are cached so it should be fine to
+  // look this up over and over.
+  //
   // We have to disable this because it's built via the Vite client build.
   // eslint-disable-next-line n/no-missing-require, n/no-unpublished-require
-  _manifest = require('../../dist/manifest.json');
-  return _manifest;
-}
+  const manifest = require('../../dist/manifest.json');
 
-function getFaviconAssetUrls() {
-  const manifest = getManifest();
   const icoAssetPath = path.join('/', manifest['client/img/favicon.ico'].file);
   const svgAssetFile = path.join('/', manifest['client/img/favicon.svg'].file);
 
-  return {
+  _faviconAssetUrls = {
     ico: icoAssetPath,
     svg: svgAssetFile,
   };
+  return _faviconAssetUrls;
 }
 
 module.exports = getFaviconAssetUrls;


### PR DESCRIPTION
Cache derived info from the `manifest.json`:

 - Like getting all of the dependencies for a given entry point
 - And the favicons
 
Also fix the problem where `server/hydrogen-render/render-page-html.js` was calling `getFaviconAssetUrls()` right away before the client build had a chance to generate `dist/manifest.json` and result in `Error: Cannot find module '../../dist/manifest.json'`