### PR TITLE
Don't jump calendar around for events which appear in the future

### DIFF
--- a/shared/views/ArchiveRoomView.js
+++ b/shared/views/ArchiveRoomView.js
@@ -185,7 +185,11 @@ class ArchiveRoomView extends TemplateView {
             if (entry.isIntersecting) {
               const eventId = entry.target.getAttribute('data-event-id');
               const eventEntry = vm.eventEntriesByEventId[eventId];
-              vm.setCurrentTopPositionEventEntry(eventEntry);
+
+              // Ignore events which appear in the future
+              if (eventEntry.timestamp <= vm.dayTimestampTo) {
+                vm.setCurrentTopPositionEventEntry(eventEntry);
+              }
             }
           });
         },


### PR DESCRIPTION
Don't jump calendar around for events which appear in the future compared to the timestamp in the URL.

This sort of situation occurs often for Gitter imported historical rooms where we have a bunch of history that is timestamp massaged intermixed with a bunch of join events which we couldn't timestamp massage at the time.

Fix https://github.com/matrix-org/matrix-public-archive/issues/182

Before | After
--- | ---
![](https://user-images.githubusercontent.com/558581/234801054-dfe51ce1-4fa7-4c76-9c37-8df601da76bb.gif) | ![](https://user-images.githubusercontent.com/558581/234801076-8fafa2d9-b2b5-43d7-ba29-0898c97fae84.gif)






### Dev notes

http://192.168.1.149:3050/r/gitter-imported-history-ts-massaging:my.synapse.server/date/2022/05/05