### PR TITLE
Fix broken links with the `matrix-media-repo` because there are too many slashes

### DIFF
--- a/shared/hydrogen-vm-render-script.js
+++ b/shared/hydrogen-vm-render-script.js
@@ -82,7 +82,8 @@ async function mountHydrogen() {
   urlRouter.attach();
 
   const mediaRepository = new MediaRepository({
-    homeserver: config.matrixServerUrl,
+    // Strip the trailing slash from the URL
+    homeserver: config.matrixServerUrl.replace(/\/$/, ''),
   });
 
   const room = {


### PR DESCRIPTION
Fix broken links with the [`matrix-media-repo`](https://github.com/turt2live/matrix-media-repo) because there are too many slashes

Before:

```
http://localhost:8008//_matrix/media/r0/thumbnail/my.synapse.server/abcde?width=30&height=30&method=crop
```

After:

```
http://localhost:8008/_matrix/media/r0/thumbnail/my.synapse.server/abcde?width=30&height=30&method=crop
```

The extra slash seems to work fine with the built-in media repo in Synapse but noticed broken links when using `matrix.org` which delegates to the `matrix-media-repo`