### PR TITLE
Set `X-Date-Temporal-Context` header for easy cache rules

### DIFF
--- a/server/lib/set-headers-for-date-temporal-context.js
+++ b/server/lib/set-headers-for-date-temporal-context.js
@@ -5,17 +5,19 @@ const assert = require('assert');
 const { getUtcStartOfDayTs } = require('matrix-public-archive-shared/lib/timestamp-utilities');
 
 // `X-Date-Temporal-Context` indicates the temporal context of the content, whether it
-// is related to past, present, or future *day*. This is useful for caching purposes so
-// you can heavily cache past content, but not present/future.
+// is related to past, present, or future *day*.
+//
+// This is useful for caching purposes so you can heavily cache past content, but not
+// present/future.
 function setHeadersForDateTemporalContext({ res, nowTs, comparedToUrlDate: { yyyy, mm, dd } }) {
   assert(res);
-  assert(nowTs);
-  assert(yyyy);
-  assert(mm);
-  assert(dd);
+  assert(Number.isInteger(nowTs));
+  assert(Number.isInteger(yyyy));
+  assert(Number.isInteger(mm));
+  assert(Number.isInteger(dd));
 
-  // We use the start of the UTC day so we can compare apples to apples and see whether
-  // yyyy-mm-dd is the past/present/future day.
+  // We use the start of the UTC day so we can compare apples to apples with a new date
+  // constructed with yyyy-mm-dd (no time occured since the start of the day)
   const startOfTodayTs = getUtcStartOfDayTs(nowTs);
   const compareTs = Date.UTC(yyyy, mm, dd);
 

--- a/server/lib/set-headers-for-date-temporal-context.js
+++ b/server/lib/set-headers-for-date-temporal-context.js
@@ -1,0 +1,32 @@
+'use strict';
+
+const assert = require('assert');
+
+const { getUtcStartOfDayTs } = require('matrix-public-archive-shared/lib/timestamp-utilities');
+
+// `X-Date-Temporal-Context` indicates the temporal context of the content, whether it
+// is related to past, present, or future *day*. This is useful for caching purposes so
+// you can heavily cache past content, but not present/future.
+function setHeadersForDateTemporalContext({ res, nowTs, comparedToUrlDate: { yyyy, mm, dd } }) {
+  assert(res);
+  assert(nowTs);
+  assert(yyyy);
+  assert(mm);
+  assert(dd);
+
+  // We use the start of the UTC day so we can compare apples to apples and see whether
+  // yyyy-mm-dd is the past/present/future day.
+  const startOfTodayTs = getUtcStartOfDayTs(nowTs);
+  const compareTs = Date.UTC(yyyy, mm, dd);
+
+  let temporalContext = 'present';
+  if (compareTs < startOfTodayTs) {
+    temporalContext = 'past';
+  } else if (compareTs > startOfTodayTs) {
+    temporalContext = 'future';
+  }
+
+  res.set('X-Date-Temporal-Context', temporalContext);
+}
+
+module.exports = setHeadersForDateTemporalContext;

--- a/server/lib/set-headers-to-preload-assets.js
+++ b/server/lib/set-headers-to-preload-assets.js
@@ -70,7 +70,7 @@ function setHeadersToPreloadAssets(res, pageOptions) {
     return `<${scriptUrl}>; rel=modulepreload`;
   });
 
-  res.append('Link', [].concat(styleLinks, fontLinks, imageLinks, scriptLinks).join(', '));
+  res.set('Link', [].concat(styleLinks, fontLinks, imageLinks, scriptLinks).join(', '));
 }
 
 module.exports = setHeadersToPreloadAssets;


### PR DESCRIPTION
Set `X-Date-Temporal-Context: [past|present|future]` header for easy cache rules:

 - Cache `past` things heavily
 - Cache `present`/`future` things for 5 minutes
 
This accomplishes the goal we set out for:

> - We can cache all responses except for the latest UTC day (and anything in the future). ex. `/!aMzLHLvScQCGKDNqCB:gitter.im/date/2022/10/13`
>    - For the latest day, we could set the cache expire after 5 minutes or so
>
> *-- [Matrix Public Archive deployment issue](https://github.com/vector-im/sre-internal/issues/2079)*

And this way we don't have to do any fancy date parsing and comparison from the URL which is probably not even possible Cloudflare cache rules.


### Todo

 - [x] Add tests