### PR TITLE
Fix time selector showing when less than the page limit of messages

### DIFF
--- a/server/routes/room-routes.js
+++ b/server/routes/room-routes.js
@@ -922,8 +922,9 @@ router.get(
         stateEventMap,
         shouldIndex,
         config: {
-          basePath: basePath,
-          matrixServerUrl: matrixServerUrl,
+          basePath,
+          matrixServerUrl,
+          archiveMessageLimit,
         },
       },
       abortSignal: req.abortSignal,

--- a/shared/hydrogen-vm-render-script.js
+++ b/shared/hydrogen-vm-render-script.js
@@ -31,6 +31,7 @@ const config = window.matrixPublicArchiveContext.config;
 assert(config);
 assert(config.matrixServerUrl);
 assert(config.basePath);
+assert(config.archiveMessageLimit);
 
 function addSupportClasses() {
   const input = document.createElement('input');
@@ -108,6 +109,7 @@ async function mountHydrogen() {
     history: archiveHistory,
     // Our options
     homeserverUrl: config.matrixServerUrl,
+    archiveMessageLimit: config.archiveMessageLimit,
     room,
     // The timestamp from the URL that was originally visited
     dayTimestampTo: toTimestamp,

--- a/shared/viewmodels/ArchiveRoomViewModel.js
+++ b/shared/viewmodels/ArchiveRoomViewModel.js
@@ -67,6 +67,7 @@ class ArchiveRoomViewModel extends ViewModel {
     super(options);
     const {
       homeserverUrl,
+      archiveMessageLimit,
       room,
       dayTimestampTo,
       precisionFromUrl,
@@ -77,6 +78,7 @@ class ArchiveRoomViewModel extends ViewModel {
       basePath,
     } = options;
     assert(homeserverUrl);
+    assert(archiveMessageLimit);
     assert(room);
     assert(dayTimestampTo);
     assert(Object.values(TIME_PRECISION_VALUES).includes(precisionFromUrl));
@@ -141,13 +143,15 @@ class ArchiveRoomViewModel extends ViewModel {
       matrixPublicArchiveURLCreator: this._matrixPublicArchiveURLCreator,
     });
 
+    console.log('events.length', events.length);
     const shouldShowTimeSelector =
       // If there are no events, then it's possible the user navigated too far back
       // before the room was created and we will let them pick a new time that might make
       // more sense. But only if they are worried about time precision in the URL already.
       (precisionFromUrl !== TIME_PRECISION_VALUES.none && !events.length) ||
-      // Only show the time selector when we're showing events all from the same day.
-      (events.length &&
+      // Only show the time selector when we're showing events all from the same day and
+      // there are more events than the limit
+      (events.length > archiveMessageLimit &&
         areTimestampsFromSameUtcDay(timelineRangeStartTimestamp, timelineRangeEndTimestamp));
 
     this._timeSelectorViewModel = new TimeSelectorViewModel({

--- a/shared/viewmodels/ArchiveRoomViewModel.js
+++ b/shared/viewmodels/ArchiveRoomViewModel.js
@@ -143,7 +143,6 @@ class ArchiveRoomViewModel extends ViewModel {
       matrixPublicArchiveURLCreator: this._matrixPublicArchiveURLCreator,
     });
 
-    console.log('events.length', events.length);
     const shouldShowTimeSelector =
       // If there are no events, then it's possible the user navigated too far back
       // before the room was created and we will let them pick a new time that might make

--- a/test/e2e-tests.js
+++ b/test/e2e-tests.js
@@ -697,17 +697,23 @@ describe('matrix-public-archive', () => {
         });
 
         it('does not show time selector when all events from the same day but not over the limit', async () => {
-          // Set this low so we don't have to deal with many messages in the tests
-          config.set('archiveMessageLimit', 5);
+          // Set this low so we don't have to deal with many messages in the tests But
+          // high enough to encompass all of the primoridial room creation events +
+          // whatever messages we send in the room for this test.
+          config.set('archiveMessageLimit', 15);
 
           const client = await getTestClientForHs(testMatrixServerUrl1);
+          // FIXME: This test is flawed and needs MSC3997 to timestamp massage the
+          // `/createRoom` events otherwise the `areTimestampsFromSameUtcDay(...)` will
+          // always be false because the create room events are from today vs the
+          // timestamp massaged messages we send below.
           const roomId = await createTestRoom(client);
 
           await createMessagesInRoom({
             client,
             roomId,
             // This should be lesser than the `archiveMessageLimit`
-            numMessages: 3,
+            numMessages: 1,
             prefix: `foo`,
             timestamp: archiveDate.getTime(),
             // Just spread things out a bit so the event times are more obvious


### PR DESCRIPTION
Fix time selector showing when less than the page limit of messages

Fix https://github.com/matrix-org/matrix-public-archive/issues/211