### PR TITLE
Add some `<meta name="description" ...>` to pages

### DIFF
--- a/server/hydrogen-render/render-page-html.js
+++ b/server/hydrogen-render/render-page-html.js
@@ -46,9 +46,9 @@ function renderPageHtml({
           <meta name="viewport" content="width=device-width, initial-scale=1">
           ${maybeNoIndexHtml}
           ${sanitizeHtml(`<title>${pageOptions.title}</title>`)}
+          ${sanitizeHtml(`<meta name="description" content="${pageOptions.description}">`)}
           <link rel="icon" href="${faviconMap.ico}" sizes="any">
           <link rel="icon" href="${faviconMap.svg}" type="image/svg+xml">
-          ${sanitizeHtml(`<meta name="description" content="${pageOptions.description}">`)}
           ${styles
             .map(
               (styleUrl) =>

--- a/server/hydrogen-render/render-page-html.js
+++ b/server/hydrogen-render/render-page-html.js
@@ -17,6 +17,7 @@ function renderPageHtml({
   assert(vmRenderContext);
   assert(pageOptions);
   assert(pageOptions.title);
+  assert(pageOptions.description);
   assert(pageOptions.entryPoint);
   assert(pageOptions.cspNonce);
 
@@ -47,6 +48,7 @@ function renderPageHtml({
           ${sanitizeHtml(`<title>${pageOptions.title}</title>`)}
           <link rel="icon" href="${faviconMap.ico}" sizes="any">
           <link rel="icon" href="${faviconMap.svg}" type="image/svg+xml">
+          ${sanitizeHtml(`<meta name="description" content="${pageOptions.description}">`)}
           ${styles
             .map(
               (styleUrl) =>

--- a/server/middleware/timeout-middleware.js
+++ b/server/middleware/timeout-middleware.js
@@ -83,6 +83,7 @@ async function timeoutMiddleware(req, res, next) {
 
     const pageOptions = {
       title: `Server timeout - Matrix Public Archive`,
+      description: `Unable to respond in time (${requestTimeoutMs / 1000}s)`,
       entryPoint: 'client/js/entry-client-timeout.js',
       locationHref: urlJoin(basePath, req.originalUrl),
       // We don't have a Matrix room so we don't know whether or not to index. Just choose

--- a/server/routes/client-side-room-alias-hash-redirect-route.js
+++ b/server/routes/client-side-room-alias-hash-redirect-route.js
@@ -15,6 +15,7 @@ assert(basePath);
 function clientSideRoomAliasHashRedirectRoute(req, res) {
   const pageOptions = {
     title: `Page not found - Matrix Public Archive`,
+    description: `This page does not exist but we may be able to redirect you to the right place.`,
     entryPoint: 'client/js/entry-client-room-alias-hash-redirect.js',
     locationHref: urlJoin(basePath, req.originalUrl),
     // We don't have a Matrix room so we don't know whether or not to index. Just choose
@@ -30,7 +31,7 @@ function clientSideRoomAliasHashRedirectRoute(req, res) {
         404: Page not found.
         <span class="js-try-redirect-message" style="display: none">One sec while we try to redirect you to the right place.</span>
       </h1>
-      <p>If there was a #room_alias:server hash in the URL, we tried redirecting  you to the right place.</p>
+      <p>If there was a #room_alias:server hash in the URL, we tried redirecting you to the right place.</p>
       <p>
         Otherwise, you're simply in a place that does not exist.
         You can ${sanitizeHtml(`<a href="${basePath}">go back to the homepage</a>.`)}

--- a/server/routes/room-directory-routes.js
+++ b/server/routes/room-directory-routes.js
@@ -75,7 +75,8 @@ router.get(
 
     const pageOptions = {
       title: `Matrix Public Archive`,
-      description: 'Browse thousands of rooms using Matrix...',
+      description:
+        'Browse thousands of rooms using Matrix. The new portal into the Matrix ecosystem.',
       entryPoint: 'client/js/entry-client-room-directory.js',
       locationHref: urlJoin(basePath, req.originalUrl),
       shouldIndex,

--- a/server/routes/room-directory-routes.js
+++ b/server/routes/room-directory-routes.js
@@ -75,6 +75,7 @@ router.get(
 
     const pageOptions = {
       title: `Matrix Public Archive`,
+      description: 'Browse thousands of rooms using Matrix...',
       entryPoint: 'client/js/entry-client-room-directory.js',
       locationHref: urlJoin(basePath, req.originalUrl),
       shouldIndex,

--- a/server/routes/room-routes.js
+++ b/server/routes/room-routes.js
@@ -898,6 +898,7 @@ router.get(
 
     const pageOptions = {
       title: `${roomData.name} - Matrix Public Archive`,
+      description: `View the history of ${roomData.name} in the Matrix Public Archive`,
       entryPoint: 'client/js/entry-client-hydrogen.js',
       locationHref: urlJoin(basePath, req.originalUrl),
       shouldIndex,


### PR DESCRIPTION
Add some `<meta name="description" ...>` to pages. 

Not the best but probably better than the default (a good first iteration)

Part of https://github.com/matrix-org/matrix-public-archive/issues/202


### Dev notes

 - https://developers.google.com/search/docs/appearance/snippet