### PR TITLE
Fix `debugActiveDateIntersectionObserver` checkbox being checked by default when the value was actually `null`

### DIFF
--- a/shared/viewmodels/DeveloperOptionsContentViewModel.js
+++ b/shared/viewmodels/DeveloperOptionsContentViewModel.js
@@ -14,16 +14,24 @@ class DeveloperOptionsContentViewModel extends ViewModel {
   }
 
   loadValuesFromPersistence() {
+    // Debugging is disabled by default and only enabled with the correct 'true' value
+    let debugActiveDateIntersectionObserver = false;
+
     if (window.localStorage) {
-      this._debugActiveDateIntersectionObserver = JSON.parse(
-        window.localStorage.getItem(LOCAL_STORAGE_KEYS.debugActiveDateIntersectionObserver)
+      const debugActiveDateIntersectionObserverFromPersistence = window.localStorage.getItem(
+        LOCAL_STORAGE_KEYS.debugActiveDateIntersectionObserver
       );
-      this.emitChange('debugActiveDateIntersectionObserver');
+
+      if (debugActiveDateIntersectionObserverFromPersistence === 'true') {
+        debugActiveDateIntersectionObserver = true;
+      }
     } else {
       console.warn(
         `Skipping \`${LOCAL_STORAGE_KEYS.debugActiveDateIntersectionObserver}\` read from LocalStorage since LocalStorage is not available`
       );
     }
+
+    this.toggleDebugActiveDateIntersectionObserver(debugActiveDateIntersectionObserver);
   }
 
   get debugActiveDateIntersectionObserver() {
@@ -32,10 +40,17 @@ class DeveloperOptionsContentViewModel extends ViewModel {
 
   toggleDebugActiveDateIntersectionObserver(checkedValue) {
     this._debugActiveDateIntersectionObserver = checkedValue;
-    window.localStorage.setItem(
-      LOCAL_STORAGE_KEYS.debugActiveDateIntersectionObserver,
-      this._debugActiveDateIntersectionObserver
-    );
+    if (window.localStorage) {
+      window.localStorage.setItem(
+        LOCAL_STORAGE_KEYS.debugActiveDateIntersectionObserver,
+        this._debugActiveDateIntersectionObserver ? 'true' : 'false'
+      );
+    } else {
+      console.warn(
+        `Skipping \`${LOCAL_STORAGE_KEYS.debugActiveDateIntersectionObserver}\` write to LocalStorage since LocalStorage is not available`
+      );
+    }
+
     this.emitChange('debugActiveDateIntersectionObserver');
   }
 


### PR DESCRIPTION
Fix `debugActiveDateIntersectionObserver` checkbox being checked by default when the value was actually `null`. Now we properly only care about explicit `'true'`, `'false'` from local storage.

Before | After
--- | ---
![](https://user-images.githubusercontent.com/558581/236582481-8523be43-ea99-491f-be24-680bd25c0de4.png) | ![](https://user-images.githubusercontent.com/558581/236582441-3536e92b-7928-410d-8e3d-b1cbc6ebd48b.png)




Before:
```
<input id="debugActiveDateIntersectionObserver" type="checkbox" checked="null">
```

After:
```
<input id="debugActiveDateIntersectionObserver" type="checkbox">
```