### PR TITLE
Better grammar in URL preview description

### DIFF
--- a/server/routes/room-routes.js
+++ b/server/routes/room-routes.js
@@ -906,7 +906,7 @@ router.get(
 
     const pageOptions = {
       title: `${roomData.name} - Matrix Public Archive`,
-      description: `View the history of ${roomData.name} in the Matrix Public Archive`,
+      description: `View the history of the ${roomData.name} room in the Matrix Public Archive`,
       imageUrl:
         roomData.avatarUrl &&
         mxcUrlToHttpThumbnail({


### PR DESCRIPTION
Better grammar in URL preview description

Part of https://github.com/matrix-org/matrix-public-archive/issues/202


Before | After
--- | ---
![](https://github.com/matrix-org/matrix-public-archive/assets/558581/52e6245a-6bb3-43ef-a8a0-3babdaf38324) | TODO

