### PR TITLE
Update Hydrogen SDK to include MXC URL's on media

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "license": "Apache-2.0",
       "dependencies": {
+        "@mlm/hydrogen-view-sdk": "^0.28.0-scratch",
         "@opentelemetry/api": "^1.4.1",
         "@opentelemetry/auto-instrumentations-node": "^0.36.6",
         "@opentelemetry/context-async-hooks": "^1.12.0",
@@ -623,6 +624,18 @@
       "resolved": "https://gitlab.matrix.org/api/v4/projects/27/packages/npm/@matrix-org/olm/-/@matrix-org/olm-3.2.14.tgz",
       "integrity": "sha512-Yz8X5+R1PL0RwJNjuH4r9WgWgXHX5v4NB093baUUE3Wh1INHEminESeur6FtIfQhVRQd8UZ9HRBh+Rd2nkNFGQ==",
       "license": "Apache-2.0"
+    },
+    "node_modules/@mlm/hydrogen-view-sdk": {
+      "version": "0.28.0-scratch",
+      "resolved": "https://registry.npmjs.org/@mlm/hydrogen-view-sdk/-/hydrogen-view-sdk-0.28.0-scratch.tgz",
+      "integrity": "sha512-Nc6hv7VxnE6UOsH+hbgXS4m9i/U5SE8P63RP68pwU0O3uasExJBnu9kfIb2pTi91TcTsCbT+1Ck0Z3fk7yCI6w==",
+      "dependencies": {
+        "@matrix-org/olm": "https://gitlab.matrix.org/api/v4/projects/27/packages/npm/@matrix-org/olm/-/@matrix-org/olm-3.2.14.tgz",
+        "another-json": "^0.2.0",
+        "base64-arraybuffer": "^0.2.0",
+        "dompurify": "^2.3.0",
+        "off-color": "^2.0.0"
+      }
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -5692,6 +5705,18 @@
     "@matrix-org/olm": {
       "version": "https://gitlab.matrix.org/api/v4/projects/27/packages/npm/@matrix-org/olm/-/@matrix-org/olm-3.2.14.tgz",
       "integrity": "sha512-Yz8X5+R1PL0RwJNjuH4r9WgWgXHX5v4NB093baUUE3Wh1INHEminESeur6FtIfQhVRQd8UZ9HRBh+Rd2nkNFGQ=="
+    },
+    "@mlm/hydrogen-view-sdk": {
+      "version": "0.28.0-scratch",
+      "resolved": "https://registry.npmjs.org/@mlm/hydrogen-view-sdk/-/hydrogen-view-sdk-0.28.0-scratch.tgz",
+      "integrity": "sha512-Nc6hv7VxnE6UOsH+hbgXS4m9i/U5SE8P63RP68pwU0O3uasExJBnu9kfIb2pTi91TcTsCbT+1Ck0Z3fk7yCI6w==",
+      "requires": {
+        "@matrix-org/olm": "https://gitlab.matrix.org/api/v4/projects/27/packages/npm/@matrix-org/olm/-/@matrix-org/olm-3.2.14.tgz",
+        "another-json": "^0.2.0",
+        "base64-arraybuffer": "^0.2.0",
+        "dompurify": "^2.3.0",
+        "off-color": "^2.0.0"
+      }
     },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "0.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@mlm/hydrogen-view-sdk": "^0.28.0-scratch",
         "@opentelemetry/api": "^1.4.1",
         "@opentelemetry/auto-instrumentations-node": "^0.36.6",
         "@opentelemetry/context-async-hooks": "^1.12.0",
@@ -24,7 +23,7 @@
         "dompurify": "^2.3.9",
         "escape-string-regexp": "^4.0.0",
         "express": "^4.17.2",
-        "hydrogen-view-sdk": "npm:@mlm/hydrogen-view-sdk@^0.27.0-scratch",
+        "hydrogen-view-sdk": "npm:@mlm/hydrogen-view-sdk@^0.28.0-scratch",
         "json5": "^2.2.1",
         "linkedom": "^0.14.17",
         "matrix-public-archive-shared": "file:./shared/",
@@ -624,18 +623,6 @@
       "resolved": "https://gitlab.matrix.org/api/v4/projects/27/packages/npm/@matrix-org/olm/-/@matrix-org/olm-3.2.14.tgz",
       "integrity": "sha512-Yz8X5+R1PL0RwJNjuH4r9WgWgXHX5v4NB093baUUE3Wh1INHEminESeur6FtIfQhVRQd8UZ9HRBh+Rd2nkNFGQ==",
       "license": "Apache-2.0"
-    },
-    "node_modules/@mlm/hydrogen-view-sdk": {
-      "version": "0.28.0-scratch",
-      "resolved": "https://registry.npmjs.org/@mlm/hydrogen-view-sdk/-/hydrogen-view-sdk-0.28.0-scratch.tgz",
-      "integrity": "sha512-Nc6hv7VxnE6UOsH+hbgXS4m9i/U5SE8P63RP68pwU0O3uasExJBnu9kfIb2pTi91TcTsCbT+1Ck0Z3fk7yCI6w==",
-      "dependencies": {
-        "@matrix-org/olm": "https://gitlab.matrix.org/api/v4/projects/27/packages/npm/@matrix-org/olm/-/@matrix-org/olm-3.2.14.tgz",
-        "another-json": "^0.2.0",
-        "base64-arraybuffer": "^0.2.0",
-        "dompurify": "^2.3.0",
-        "off-color": "^2.0.0"
-      }
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -3294,9 +3281,9 @@
     },
     "node_modules/hydrogen-view-sdk": {
       "name": "@mlm/hydrogen-view-sdk",
-      "version": "0.27.0-scratch",
-      "resolved": "https://registry.npmjs.org/@mlm/hydrogen-view-sdk/-/hydrogen-view-sdk-0.27.0-scratch.tgz",
-      "integrity": "sha512-wv6GLeAFpdQdAVDSTSiWehslGKxn5DDcS7MtxiL8E2J9OJJkd2VoVncmNrrJ86FN5nORTpbD879HDZ1yevfi9g==",
+      "version": "0.28.0-scratch",
+      "resolved": "https://registry.npmjs.org/@mlm/hydrogen-view-sdk/-/hydrogen-view-sdk-0.28.0-scratch.tgz",
+      "integrity": "sha512-Nc6hv7VxnE6UOsH+hbgXS4m9i/U5SE8P63RP68pwU0O3uasExJBnu9kfIb2pTi91TcTsCbT+1Ck0Z3fk7yCI6w==",
       "dependencies": {
         "@matrix-org/olm": "https://gitlab.matrix.org/api/v4/projects/27/packages/npm/@matrix-org/olm/-/@matrix-org/olm-3.2.14.tgz",
         "another-json": "^0.2.0",
@@ -5706,18 +5693,6 @@
       "version": "https://gitlab.matrix.org/api/v4/projects/27/packages/npm/@matrix-org/olm/-/@matrix-org/olm-3.2.14.tgz",
       "integrity": "sha512-Yz8X5+R1PL0RwJNjuH4r9WgWgXHX5v4NB093baUUE3Wh1INHEminESeur6FtIfQhVRQd8UZ9HRBh+Rd2nkNFGQ=="
     },
-    "@mlm/hydrogen-view-sdk": {
-      "version": "0.28.0-scratch",
-      "resolved": "https://registry.npmjs.org/@mlm/hydrogen-view-sdk/-/hydrogen-view-sdk-0.28.0-scratch.tgz",
-      "integrity": "sha512-Nc6hv7VxnE6UOsH+hbgXS4m9i/U5SE8P63RP68pwU0O3uasExJBnu9kfIb2pTi91TcTsCbT+1Ck0Z3fk7yCI6w==",
-      "requires": {
-        "@matrix-org/olm": "https://gitlab.matrix.org/api/v4/projects/27/packages/npm/@matrix-org/olm/-/@matrix-org/olm-3.2.14.tgz",
-        "another-json": "^0.2.0",
-        "base64-arraybuffer": "^0.2.0",
-        "dompurify": "^2.3.0",
-        "off-color": "^2.0.0"
-      }
-    },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -7547,9 +7522,9 @@
       }
     },
     "hydrogen-view-sdk": {
-      "version": "npm:@mlm/hydrogen-view-sdk@0.27.0-scratch",
-      "resolved": "https://registry.npmjs.org/@mlm/hydrogen-view-sdk/-/hydrogen-view-sdk-0.27.0-scratch.tgz",
-      "integrity": "sha512-wv6GLeAFpdQdAVDSTSiWehslGKxn5DDcS7MtxiL8E2J9OJJkd2VoVncmNrrJ86FN5nORTpbD879HDZ1yevfi9g==",
+      "version": "npm:@mlm/hydrogen-view-sdk@0.28.0-scratch",
+      "resolved": "https://registry.npmjs.org/@mlm/hydrogen-view-sdk/-/hydrogen-view-sdk-0.28.0-scratch.tgz",
+      "integrity": "sha512-Nc6hv7VxnE6UOsH+hbgXS4m9i/U5SE8P63RP68pwU0O3uasExJBnu9kfIb2pTi91TcTsCbT+1Ck0Z3fk7yCI6w==",
       "requires": {
         "@matrix-org/olm": "https://gitlab.matrix.org/api/v4/projects/27/packages/npm/@matrix-org/olm/-/@matrix-org/olm-3.2.14.tgz",
         "another-json": "^0.2.0",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "vite": "^4.3.1"
   },
   "dependencies": {
-    "@mlm/hydrogen-view-sdk": "^0.28.0-scratch",
     "@opentelemetry/api": "^1.4.1",
     "@opentelemetry/auto-instrumentations-node": "^0.36.6",
     "@opentelemetry/context-async-hooks": "^1.12.0",
@@ -51,7 +50,7 @@
     "dompurify": "^2.3.9",
     "escape-string-regexp": "^4.0.0",
     "express": "^4.17.2",
-    "hydrogen-view-sdk": "npm:@mlm/hydrogen-view-sdk@^0.27.0-scratch",
+    "hydrogen-view-sdk": "npm:@mlm/hydrogen-view-sdk@^0.28.0-scratch",
     "json5": "^2.2.1",
     "linkedom": "^0.14.17",
     "matrix-public-archive-shared": "file:./shared/",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "vite": "^4.3.1"
   },
   "dependencies": {
+    "@mlm/hydrogen-view-sdk": "^0.28.0-scratch",
     "@opentelemetry/api": "^1.4.1",
     "@opentelemetry/auto-instrumentations-node": "^0.36.6",
     "@opentelemetry/context-async-hooks": "^1.12.0",


### PR DESCRIPTION
Update Hydrogen SDK to include MXC URL's on media

Useful in moderation scenarios where you want to quarantine media and can quickly/easily look at the data attribute on the media (image/videos). Or simply write a little script to extract all of the `data-mxc-url` and `data-thumbnail-mxc-url` attributes.

ex.
```
<img src="http://localhost:8008/_matrix/media/r0/thumbnail/my.synapse.server/TEyTVUNgvUQZcXlrLwgGfbcp?width=400&amp;height=266&amp;method=scale" alt="Stormclouds.jpg" title="Stormclouds.jpg" data-mxc-url="mxc://my.synapse.server/kxibKhxRfTvFWyuWwWvFuBtE" data-thumbnail-mxc-url="mxc://my.synapse.server/TEyTVUNgvUQZcXlrLwgGfbcp" style="max-width: 400px; max-height: 266px;">
```