### PR TITLE
Prevent Cloudflare from overriding our own 504 timeout page

### DIFF
--- a/config/config.default.json
+++ b/config/config.default.json
@@ -6,11 +6,12 @@
   "matrixServerUrl": "http://localhost:8008/",
   "matrixServerName": "localhost",
   // Set this to 100 since that is the max that Synapse will backfill even if you do a
-  // `/messges?limit=1000` and we don't want to miss messages in between.
+  // `/messages?limit=1000` and we don't want to miss messages in between.
   "archiveMessageLimit": 100,
   "requestTimeoutMs": 25000,
   "logOutputFromChildProcesses": false,
   //"stopSearchEngineIndexing": true,
+  "workaroundCloudflare504TimeoutErrors": false,
   // Tracing
   //"jaegerTracesEndpoint": "http://localhost:14268/api/traces",
 


### PR DESCRIPTION
Prevent Cloudflare from overriding our own 504 timeout page

Explored in https://gitlab.matrix.org/matrix-public-archive/deployment/-/issues/2 (internal deployment issue)

> Cloudflare returns an Cloudflare-branded HTTP 502 or 504 error when your origin web server responds with a standard HTTP 502 bad gateway or 504 gateway timeout error:
>
> *-- https://developers.cloudflare.com/support/troubleshooting/cloudflare-errors/troubleshooting-cloudflare-5xx-errors/#502504-from-your-origin-web-server*

<img src="https://github.com/matrix-org/matrix-public-archive/assets/558581/46f6d88c-ba53-4efb-809f-3f331bf9b799" width="400">


The only way to disable this functionality is to have an Enterprise Cloudflare plan and use the `Enable Origin Error Pages` option:

> **Enable Origin Error Pages**
>
> When Origin Error Page is set to “On”, Cloudflare will proxy the 502 and 504 error pages directly from the origin.
>
> Requires Enterprise or higher

So instead of dealing with that headache, we're just working around this by responding with a 500 error when we timeout. Should be good enough I think. The user won't know any difference but may affect what Search Engines think. Not sure search engines care about the distinction since the page is slow to respond anyway which they punish.