### PR TITLE
Catch NSFW rooms with underscores

### DIFF
--- a/shared/lib/check-text-for-nsfw.js
+++ b/shared/lib/check-text-for-nsfw.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const NSFW_WORDS = ['nsfw', 'porn', 'nudes', 'sex', '18+'];
-const NSFW_REGEXES = NSFW_WORDS.map((word) => new RegExp(`\\b${word}\\b`, 'i'));
+const NSFW_REGEXES = NSFW_WORDS.map((word) => new RegExp(`(\\b|_)${word}(\\b|_)`, 'i'));
 
 // A very basic check for NSFW content that just looks for some keywords in the given
 // text

--- a/test/shared/lib/check-text-for-nsfw-tests.js
+++ b/test/shared/lib/check-text-for-nsfw-tests.js
@@ -1,0 +1,25 @@
+'use strict';
+
+const assert = require('assert');
+
+const checkTextForNsfw = require('matrix-public-archive-shared/lib/check-text-for-nsfw');
+
+describe('checkTextForNsfw', () => {
+  Object.entries({
+    nsfw: true,
+    'foo NSFW bar': true,
+    foo_NSFW_bar: true,
+    'foo:NSFW:bar': true,
+    NSFW_foo: true,
+    'NSFW-foo': true,
+    'NSFW:foo': true,
+  }).forEach(([inputText, expectedNsfw]) => {
+    it(`should return ${expectedNsfw} for '${inputText}'`, () => {
+      assert.strictEqual(
+        checkTextForNsfw(inputText),
+        expectedNsfw,
+        `expected checkTextForNsfw('${inputText}') to be ${expectedNsfw}`
+      );
+    });
+  });
+});


### PR DESCRIPTION
Catch NSFW rooms with underscores

`\b` includes `_` which is a bit unexpected since we expect a room that looks like `NSFW_foo` to be caught in safe search