### PR TITLE
Document why changes to locally linked `hydrogen-view-sdk` don't trigger a rebuild

### DIFF
--- a/server/start-dev.js
+++ b/server/start-dev.js
@@ -18,6 +18,10 @@ buildClient({
   build: {
     // Rebuild when we see changes
     // https://rollupjs.org/guide/en/#watch-options
+    //
+    // We currently can't watch for changes in the locally linked `hydrogen-view-sdk`
+    // because of https://github.com/vitejs/vite/issues/8619 despite what
+    // https://vitejs.dev/config/server-options.html#server-watch says is possible.
     watch: true,
   },
 });


### PR DESCRIPTION
Document why changes to locally linked `hydrogen-view-sdk` don't trigger a rebuild