### PR TITLE
Generate tables of contents with doctoc using pre-commit

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+* text=auto
+*.md text eol=lf

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,16 @@
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+repos:
+# -   repo: https://github.com/pre-commit/pre-commit-hooks
+#     rev: v4.4.0
+#     hooks:
+#     -   id: trailing-whitespace
+#     -   id: end-of-file-fixer
+#     -   id: check-yaml
+#     -   id: check-added-large-files
+
+ - repo: https://github.com/thlorenz/doctoc
+   rev: v2.2.0
+   hooks:
+     - id: doctoc
+       args: [--update-only, --notitle]

--- a/README.md
+++ b/README.md
@@ -14,6 +14,25 @@ Room directory homepage | Archive room view
 --- | ---
 <img alt="A reference for how the Matrix Public Archive homepage looks. Search bar where you can find thousands of rooms using Matrix and homeserver selector. Grid of room cards showing the results." src="https://user-images.githubusercontent.com/558581/236579462-fee0f9c0-29d2-4c3d-a695-c9eaf0f744ef.png" width="440"> | ![A reference for how the Matrix Public Archive looks. Showing off a day of messages in `#gitter:matrix.org` on 2021-08-06. There is a date picker calendar in the right sidebar and a traditional chat app layout on the left.](https://user-images.githubusercontent.com/558581/234765275-28c70c49-c27f-473a-88ba-f4392ddae871.png)
 
+<!-- prettier-ignore-start -->
+
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+
+- [Demo videos](#demo-videos)
+- [Technical overview](#technical-overview)
+- [FAQ](#faq)
+- [Setup](#setup)
+  - [Prerequisites](#prerequisites)
+  - [Get the app running](#get-the-app-running)
+- [Development](#development)
+  - [Running tests](#running-tests)
+  - [Tracing](#tracing)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+<!-- prettier-ignore-end -->
+
 ## Demo videos
 
 - [![](https://user-images.githubusercontent.com/558581/206083768-d18456de-caa3-463f-a891-96eed8054686.png) May 2023](https://www.youtube.com/watch?v=4KlNILNItGQ&t=1046s): Introducing [archive.matrix.org](https://archive.matrix.org/), the shiny new public instance of the Matrix Public Archive that everyone can share and link to.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,5 +1,23 @@
 # FAQ
 
+<!-- prettier-ignore-start -->
+
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+
+- [Can I run my own instance?](#can-i-run-my-own-instance)
+- [How is this different from `view.matrix.org`?](#how-is-this-different-from-viewmatrixorg)
+- [How do I opt out and keep my room from being indexed by search engines?](#how-do-i-opt-out-and-keep-my-room-from-being-indexed-by-search-engines)
+- [Why does the archive user join rooms instead of browsing them as a guest?](#why-does-the-archive-user-join-rooms-instead-of-browsing-them-as-a-guest)
+- [Technical details](#technical-details)
+  - [How do I figure out what version of the Matrix Public Archive is running?](#how-do-i-figure-out-what-version-of-the-matrix-public-archive-is-running)
+  - [How does the archive room URL relate to what is displayed on the page?](#how-does-the-archive-room-url-relate-to-what-is-displayed-on-the-page)
+  - [Why does the time selector only appear for some pages?](#why-does-the-time-selector-only-appear-for-some-pages)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+<!-- prettier-ignore-end -->
+
 ## Can I run my own instance?
 
 Yes! We host a public canonical version of the Matrix Public Archive at

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,5 +1,18 @@
 # Testing
 
+<!-- prettier-ignore-start -->
+
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+
+- [Setup](#setup)
+- [Running the tests](#running-the-tests)
+  - [Developer utility](#developer-utility)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+<!-- prettier-ignore-end -->
+
 ## Setup
 
 If you haven't setup `matrix-public-archive` yet, see the [_Setup_ section in the root `README.md`](../README.md#setup)

--- a/docs/tracing.md
+++ b/docs/tracing.md
@@ -5,6 +5,19 @@ taken up in functions. This is useful for debugging and performance analysis.
 
 <img src="https://user-images.githubusercontent.com/558581/180586026-ff6c653e-a54d-4cf4-abc8-a8c51971aad5.png" width="612">
 
+<!-- prettier-ignore-start -->
+
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+
+- [Setup](#setup)
+- [Run the app with the OpenTelemetry tracing enabled](#run-the-app-with-the-opentelemetry-tracing-enabled)
+- [Viewing traces in Jaeger](#viewing-traces-in-jaeger)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+<!-- prettier-ignore-end -->
+
 ## Setup
 
 1. Get the all-in-one Jaeger Docker container running (via https://www.jaegertracing.io/docs/1.35/getting-started/)


### PR DESCRIPTION
- gitattributes enables end of line normalisation and keeps markdown files checked out with Linux line-endings as doctoc requires that.
- `pre-commit` simplifies running git's pre-commit hooks across multiple systems for developers, to enable it should be installed from package manager or pip and in the repo `pre-commit install` will run it whenever running `git commit`. It can also be ran manually with `pre-commit run --all-files`.
  - I left the sample hooks in commented as I wasn't sure whether they would be desirable and whether to drop them. They would attempt to fix line endings as there are multiple cases of them missing in the repository.
  - with doctoc `--update-only` prevents it from just adding ToC to top of all markdown files (e.g. LICENSE.md) and `--notitle` keeps "Table of Contents generated by doctoc" out of sight.

To enable `doctoc` for a new file, add this to a desired position:


```markdown
<!-- prettier-ignore-start -->

<!-- START doctoc -->
<!-- END doctoc -->

<!-- prettier-ignore-end -->
```

and run `pre-commit run --all-files`