### PR TITLE
Fix Firefox sorting room cards in the wrong direction

### DIFF
--- a/shared/viewmodels/RoomDirectoryViewModel.js
+++ b/shared/viewmodels/RoomDirectoryViewModel.js
@@ -88,9 +88,14 @@ class RoomDirectoryViewModel extends ViewModel {
       );
     });
     this._roomCardViewModelsFilterMap = new ApplyMap(this._roomCardViewModelsMap);
-    this._roomCardViewModels = this._roomCardViewModelsFilterMap.sortValues((/*a, b*/) => {
-      // Sort doesn't matter
-      return 1;
+    this._roomCardViewModels = this._roomCardViewModelsFilterMap.sortValues((a, b) => {
+      if (b.numJoinedMembers > a.numJoinedMembers) {
+        return 1;
+      } else if (b.numJoinedMembers < a.numJoinedMembers) {
+        return -1;
+      }
+
+      return 0;
     });
 
     this._safeSearchEnabled = true;

--- a/shared/viewmodels/RoomDirectoryViewModel.js
+++ b/shared/viewmodels/RoomDirectoryViewModel.js
@@ -89,6 +89,7 @@ class RoomDirectoryViewModel extends ViewModel {
     });
     this._roomCardViewModelsFilterMap = new ApplyMap(this._roomCardViewModelsMap);
     this._roomCardViewModels = this._roomCardViewModelsFilterMap.sortValues((a, b) => {
+      // Sort by the number of joined members descending (highest to lowest)
       if (b.numJoinedMembers > a.numJoinedMembers) {
         return 1;
       } else if (b.numJoinedMembers < a.numJoinedMembers) {


### PR DESCRIPTION
Fix Firefox sorting room cards in the wrong direction. They will now sort by room members descending (highest to lowest) as expected. 

Fix https://github.com/matrix-org/matrix-public-archive/issues/218

The `/publicRooms` (room directory) endpoint already returns rooms in the correct order which is why we didn't care about the order before but the different `[].sort(...)` implementations in browsers necessitates we be explicit about it. Ideally, we wouldn't have to use the `ObservableMap.sortValues()` method at all but it seems like one of the only ways to get the values out. In any case, maybe it's more clear what order things are in now.


### Root cause

This bug stems from the fact that `[1, 2, 3, 4, 5].sort((a, b) => 1)` returns different results in Chrome vs Firefox (found from https://stackoverflow.com/questions/55039157/array-sort-behaves-differently-in-firefox-and-chrome-edge)

 - Chrome: `[1, 2, 3, 4, 5].sort((a, b) => 1)` -> `[1, 2, 3, 4, 5]` :white_check_mark: 
 - Firefox: `[1, 2, 3, 4, 5].sort((a, b) => 1)` -> `[5, 4, 3, 2, 1]` :x: 


Before | After
--- | ---
![](https://github.com/matrix-org/matrix-public-archive/assets/558581/2229f442-4b70-41a3-b593-6b8830a7b95d) | ![](https://github.com/matrix-org/matrix-public-archive/assets/558581/cb97f8b6-9237-4127-a811-dbe7e1668fb3)
