### PR TITLE
Remove `libera.chat` as a default since their rooms are not accessible in the archive

### DIFF
--- a/shared/viewmodels/RoomDirectoryViewModel.js
+++ b/shared/viewmodels/RoomDirectoryViewModel.js
@@ -10,7 +10,7 @@ const HomeserverSelectionModalContentViewModel = require('matrix-public-archive-
 const RoomCardViewModel = require('matrix-public-archive-shared/viewmodels/RoomCardViewModel');
 const checkTextForNsfw = require('matrix-public-archive-shared/lib/check-text-for-nsfw');
 
-const DEFAULT_SERVER_LIST = ['matrix.org', 'gitter.im', 'libera.chat'];
+const DEFAULT_SERVER_LIST = ['matrix.org', 'gitter.im'];
 
 class RoomDirectoryViewModel extends ViewModel {
   constructor(options) {


### PR DESCRIPTION
Remove `libera.chat` as a default since their rooms are not accessible in the archive

The history visibility in Libera rooms is set to `join` (and [any other IRC bridged room](https://github.com/matrix-org/matrix-appservice-irc/blob/d49f41d89fb2e5fa469f06826268e28322a13274/src/bridge/RoomCreation.ts#L35C1-L41)) which means it's not accessible in the archive at all (only rooms with `shared` or `world_readable` history visibility are accessible in the archive). Instead of leading a bunch of people to `403 Forbidden`, we can just remove it from the default list.

The default list was mostly just copied from the `matrix.org` list of defaults shown in Element.