### PR TITLE
Add `/faq` redirect

### DIFF
--- a/server/routes/install-routes.js
+++ b/server/routes/install-routes.js
@@ -39,6 +39,14 @@ function installRoutes(app) {
     })
   );
 
+  app.get(
+    '/faq',
+    identifyRoute('faq'),
+    asyncHandler(async function (req, res) {
+      res.redirect('https://github.com/matrix-org/matrix-public-archive/blob/main/docs/faq.md');
+    })
+  );
+
   // Our own archive app styles and scripts
   app.use('/assets', express.static(path.join(__dirname, '../../dist/assets')));
 


### PR DESCRIPTION
Add `/faq` -> https://github.com/matrix-org/matrix-public-archive/blob/main/docs/faq.md redirect

Part of https://github.com/matrix-org/matrix-public-archive/issues/257 so we can set the display name of the bot to `archive.matrix.org/faq` and people can read about the project is about and why the bot joined.