### PR TITLE
Use `rel=canonical` link to de-duplicate event permalinks

### DIFF
--- a/server/hydrogen-render/render-hydrogen-to-string-unsafe.js
+++ b/server/hydrogen-render/render-hydrogen-to-string-unsafe.js
@@ -69,14 +69,14 @@ async function _renderHydrogenToStringUnsafe(renderOptions) {
   assert(renderOptions.vmRenderScriptFilePath);
   assert(renderOptions.vmRenderContext);
   assert(renderOptions.pageOptions);
-  assert(renderOptions.pageOptions.locationHref);
+  assert(renderOptions.pageOptions.locationUrl);
   assert(renderOptions.pageOptions.cspNonce);
 
   const { dom, vmContext } = createDomAndSetupVmContext();
 
   // A small `window.location` stub
   if (!dom.window.location) {
-    const locationUrl = new URL(renderOptions.pageOptions.locationHref);
+    const locationUrl = new URL(renderOptions.pageOptions.locationUrl);
     dom.window.location = {};
     [
       'hash',

--- a/server/hydrogen-render/render-page-html.js
+++ b/server/hydrogen-render/render-page-html.js
@@ -71,6 +71,11 @@ function renderPageHtml({
     metaImageUrl = pageOptions.imageUrl;
   }
 
+  let maybeRelCanonical = '';
+  if (pageOptions.canonicalUrl) {
+    maybeRelCanonical = sanitizeHtml(`<link rel="canonical" href="${pageOptions.canonicalUrl}">`);
+  }
+
   const pageHtml = `
       <!doctype html>
       <html lang="en">
@@ -83,6 +88,7 @@ function renderPageHtml({
           ${sanitizeHtml(`<meta property="og:image" content="${metaImageUrl}">`)}
           <link rel="icon" href="${pageAssetUrls.faviconIco}" sizes="any">
           <link rel="icon" href="${pageAssetUrls.faviconSvg}" type="image/svg+xml">
+          ${maybeRelCanonical}
           ${styles
             .map(
               (styleUrl) =>

--- a/server/middleware/timeout-middleware.js
+++ b/server/middleware/timeout-middleware.js
@@ -86,7 +86,7 @@ async function timeoutMiddleware(req, res, next) {
       title: `Server timeout - Matrix Public Archive`,
       description: `Unable to respond in time (${requestTimeoutMs / 1000}s)`,
       entryPoint: 'client/js/entry-client-timeout.js',
-      locationHref: urlJoin(basePath, req.originalUrl),
+      locationUrl: urlJoin(basePath, req.originalUrl),
       // We don't have a Matrix room so we don't know whether or not to index. Just choose
       // a safe-default of false.
       shouldIndex: false,

--- a/server/routes/client-side-room-alias-hash-redirect-route.js
+++ b/server/routes/client-side-room-alias-hash-redirect-route.js
@@ -17,7 +17,7 @@ function clientSideRoomAliasHashRedirectRoute(req, res) {
     title: `Page not found - Matrix Public Archive`,
     description: `This page does not exist but we may be able to redirect you to the right place.`,
     entryPoint: 'client/js/entry-client-room-alias-hash-redirect.js',
-    locationHref: urlJoin(basePath, req.originalUrl),
+    locationUrl: urlJoin(basePath, req.originalUrl),
     // We don't have a Matrix room so we don't know whether or not to index. Just choose
     // a safe-default of false.
     shouldIndex: false,

--- a/server/routes/room-directory-routes.js
+++ b/server/routes/room-directory-routes.js
@@ -78,7 +78,7 @@ router.get(
       description:
         'Browse thousands of rooms using Matrix. The new portal into the Matrix ecosystem.',
       entryPoint: 'client/js/entry-client-room-directory.js',
-      locationHref: urlJoin(basePath, req.originalUrl),
+      locationUrl: urlJoin(basePath, req.originalUrl),
       shouldIndex,
       cspNonce: res.locals.cspNonce,
     };

--- a/server/routes/room-routes.js
+++ b/server/routes/room-routes.js
@@ -916,7 +916,7 @@ router.get(
         }),
       blockedBySafeSearch: isNsfw,
       entryPoint: 'client/js/entry-client-hydrogen.js',
-      locationHref: urlJoin(basePath, req.originalUrl),
+      locationUrl: urlJoin(basePath, req.originalUrl),
       canonicalUrl: matrixPublicArchiveURLCreator.archiveUrlForDate(
         roomIdOrAlias,
         new Date(toTimestamp),

--- a/server/routes/room-routes.js
+++ b/server/routes/room-routes.js
@@ -917,6 +917,18 @@ router.get(
       blockedBySafeSearch: isNsfw,
       entryPoint: 'client/js/entry-client-hydrogen.js',
       locationHref: urlJoin(basePath, req.originalUrl),
+      canonicalUrl: matrixPublicArchiveURLCreator.archiveUrlForDate(
+        roomIdOrAlias,
+        new Date(toTimestamp),
+        {
+          preferredPrecision: precisionFromUrl,
+          // We purposely omit `scrollStartEventId` here because the canonical location
+          // for any given event ID is the page it resides on.
+          //
+          // We can avoid passing along the `viaServers` because we already joined the
+          // room above (see `ensureRoomJoined`).
+        }
+      ),
       shouldIndex,
       cspNonce: res.locals.cspNonce,
     };


### PR DESCRIPTION
Use `rel=canonical` link to de-duplicate event permalinks

Fix https://github.com/matrix-org/matrix-public-archive/issues/251

> if multiple pages are only differentiated by a query argument and contain the exact same set of messages with only tiny changes (such as in its highlighting or in its preview metadata), they should be linked back together to a single canonical URL. A search engine crawler is free to throw away any and all alternative links which fold back to the same canonical one instead of indexing each of them separately.