### PR TITLE
Prevent join event spam with stable `reason`

### DIFF
--- a/server/lib/matrix-utils/ensure-room-joined.js
+++ b/server/lib/matrix-utils/ensure-room-joined.js
@@ -52,12 +52,7 @@ async function ensureRoomJoined(
         reason:
           `Joining room to check history visibility. ` +
           `If your room is public with shared or world readable history visibility, ` +
-          `it will be accessible at ${matrixPublicArchiveURLCreator.archiveUrlForRoom(
-            roomIdOrAlias
-            // We don't need to include the `viaServers` option here because the archive
-            // will already be joined to the room from this request itself and we don't
-            // need to make the URL any longer/noisier than it needs to be.
-          )}. ` +
+          `it will be accessible on ${matrixPublicArchiveURLCreator.roomDirectoryUrl()}. ` +
           `See the FAQ for more details: ` +
           `https://github.com/matrix-org/matrix-public-archive/blob/main/docs/faq.md#why-did-the-archive-bot-join-my-room`,
       },


### PR DESCRIPTION
Prevent join event spam with stable `reason`.

In the case of someone visiting a room via an alias, we can't get access to the `room_id` before we join the room. I've opted to just point to the Matrix Public Archive instance in general. This way the `join` reason is always stable regardless how someone is visiting the room.

Fix https://github.com/matrix-org/matrix-public-archive/issues/267

Join `reason` was originally added in https://github.com/matrix-org/matrix-public-archive/pull/262