### PR TITLE
Prefer canonical room alias in `rel=canonical` link

### DIFF
--- a/server/routes/room-routes.js
+++ b/server/routes/room-routes.js
@@ -918,7 +918,7 @@ router.get(
       entryPoint: 'client/js/entry-client-hydrogen.js',
       locationUrl: urlJoin(basePath, req.originalUrl),
       canonicalUrl: matrixPublicArchiveURLCreator.archiveUrlForDate(
-        roomIdOrAlias,
+        roomData.canonicalAlias || roomIdOrAlias,
         new Date(toTimestamp),
         {
           preferredPrecision: precisionFromUrl,


### PR DESCRIPTION
Prefer canonical room alias in `rel=canonical` link

Follow-up to https://github.com/matrix-org/matrix-public-archive/pull/266

Part of https://github.com/matrix-org/matrix-public-archive/issues/251