### PR TITLE
Optimistically use Matrix API's and show world readable rooms

### DIFF
--- a/server/lib/matrix-utils/create-retry-fn-if-not-joined.js
+++ b/server/lib/matrix-utils/create-retry-fn-if-not-joined.js
@@ -1,0 +1,94 @@
+'use strict';
+
+const assert = require('assert');
+
+const { HTTPResponseError } = require('../fetch-endpoint');
+const ensureRoomJoined = require('./ensure-room-joined');
+
+const JOIN_STATES = {
+  unknown: 'unknown',
+  joining: 'joining',
+  joined: 'joined',
+  failed: 'failed',
+};
+const joinStateValues = Object.values(JOIN_STATES);
+
+// Optimistically use the Matrix API assuming you're already joined to the room or
+// accessing a `world_readable` room that doesn't require joining. If we see a 403
+// Forbidden, then try joining the room and retrying the API call.
+//
+// Usage: Call this once to first create a helper utility that will retry a given
+// function appropriately.
+function createRetryFnIfNotJoined(
+  accessToken,
+  roomIdOrAlias,
+  { viaServers = new Set(), abortSignal } = {}
+) {
+  assert(accessToken);
+  assert(roomIdOrAlias);
+  // We use a `Set` to ensure that we don't have duplicate servers in the list
+  assert(viaServers instanceof Set);
+
+  let joinState = JOIN_STATES.unknown;
+  let joinPromise = null;
+
+  return async function retryFnIfNotJoined(fn) {
+    assert(
+      joinStateValues.includes(joinState),
+      `Unexpected internal join state when using createRetryFnIfNotJoined(...) (joinState=${joinState}). ` +
+        `This is a bug in the Matrix Public Archive. Please report`
+    );
+
+    if (joinState === JOIN_STATES.joining) {
+      // Wait for the join to finish before trying
+      await joinPromise;
+    } else if (joinState === JOIN_STATES.failed) {
+      // If we failed to join the room, then there is no way any other call is going
+      // to succeed so just immediately return an error. We return `joinPromise`
+      // which will resolve to the join error that occured
+      return joinPromise;
+    }
+
+    try {
+      return await Promise.resolve(fn());
+    } catch (errFromFn) {
+      const isForbiddenError =
+        errFromFn instanceof HTTPResponseError && errFromFn.response.status === 403;
+
+      // If we're in the middle of joining, try again
+      if (joinState === JOIN_STATES.joining) {
+        return await retryFnIfNotJoined(fn);
+      }
+      // Try joining the room if we see a 403 Forbidden error as we may just not
+      // be part of the room yet. We can't distinguish between a room that has
+      // banned us vs a room we haven't joined yet so we just try joining the
+      // room in any case.
+      else if (
+        isForbiddenError &&
+        // Only try joining if we haven't tried joining yet
+        joinState === JOIN_STATES.unknown
+      ) {
+        joinState = JOIN_STATES.joining;
+        joinPromise = ensureRoomJoined(accessToken, roomIdOrAlias, {
+          viaServers,
+          abortSignal,
+        });
+
+        try {
+          await joinPromise;
+          joinState = JOIN_STATES.joined;
+          console.log('retryAfterJoin');
+          return await retryFnIfNotJoined(fn);
+        } catch (err) {
+          console.log('FAILED retryAfterJoin');
+          joinState = JOIN_STATES.failed;
+          throw err;
+        }
+      }
+
+      throw errFromFn;
+    }
+  };
+}
+
+module.exports = createRetryFnIfNotJoined;

--- a/server/lib/matrix-utils/create-retry-fn-if-not-joined.js
+++ b/server/lib/matrix-utils/create-retry-fn-if-not-joined.js
@@ -77,10 +77,8 @@ function createRetryFnIfNotJoined(
         try {
           await joinPromise;
           joinState = JOIN_STATES.joined;
-          console.log('retryAfterJoin');
           return await retryFnIfNotJoined(fn);
         } catch (err) {
-          console.log('FAILED retryAfterJoin');
           joinState = JOIN_STATES.failed;
           throw err;
         }

--- a/server/lib/matrix-utils/ensure-room-joined.js
+++ b/server/lib/matrix-utils/ensure-room-joined.js
@@ -21,6 +21,8 @@ async function ensureRoomJoined(
   roomIdOrAlias,
   { viaServers = new Set(), abortSignal } = {}
 ) {
+  assert(accessToken);
+  assert(roomIdOrAlias);
   // We use a `Set` to ensure that we don't have duplicate servers in the list
   assert(viaServers instanceof Set);
 

--- a/server/lib/matrix-utils/fetch-public-rooms.js
+++ b/server/lib/matrix-utils/fetch-public-rooms.js
@@ -40,11 +40,12 @@ async function fetchPublicRooms(
     abortSignal,
   });
 
-  // We only want to see public rooms in the archive
+  // We only want to see public or world_readable rooms in the archive. A room can be
+  // world_readable without being public. For example someone might have an invite only
+  // room where only privileged users are allowed to join and talk but anyone can view
+  // the room.
   const accessibleRooms = publicRoomsRes.chunk.filter((room) => {
-    // `room.world_readable` is also accessible here but we only use history
-    // `world_readable` to determine search indexing.
-    return room.join_rule === 'public';
+    return room.world_readable || room.join_rule === 'public';
   });
 
   return {

--- a/server/lib/matrix-utils/resolve-room-alias.js
+++ b/server/lib/matrix-utils/resolve-room-alias.js
@@ -1,0 +1,33 @@
+'use strict';
+
+const assert = require('assert');
+const urlJoin = require('url-join');
+
+const { fetchEndpointAsJson } = require('../fetch-endpoint');
+const { traceFunction } = require('../../tracing/trace-utilities');
+
+const config = require('../config');
+const matrixServerUrl = config.get('matrixServerUrl');
+assert(matrixServerUrl);
+
+async function resolveRoomAlias({ accessToken, roomAlias, abortSignal }) {
+  assert(accessToken);
+  assert(roomAlias);
+
+  // GET /_matrix/client/r0/directory/room/{roomAlias} -> { room_id, servers }
+  const resolveRoomAliasEndpoint = urlJoin(
+    matrixServerUrl,
+    `_matrix/client/r0/directory/room/${encodeURIComponent(roomAlias)}`
+  );
+  const { data: resolveRoomAliasResData } = await fetchEndpointAsJson(resolveRoomAliasEndpoint, {
+    accessToken,
+    abortSignal,
+  });
+
+  return {
+    roomId: resolveRoomAliasResData.room_id,
+    viaServers: new Set(resolveRoomAliasResData.servers || []),
+  };
+}
+
+module.exports = traceFunction(resolveRoomAlias);

--- a/server/lib/matrix-utils/resolve-room-id-or-alias.js
+++ b/server/lib/matrix-utils/resolve-room-id-or-alias.js
@@ -1,0 +1,40 @@
+'use strict';
+
+const {
+  VALID_ENTITY_DESCRIPTOR_TO_SIGIL_MAP,
+} = require('matrix-public-archive-shared/lib/reference-values');
+const resolveRoomAlias = require('./resolve-room-alias');
+
+// Given a room ID or alias, return the room ID and the set of servers we should try to
+// join from. Does not attempt to join the room.
+async function resolveRoomIdOrAlias({
+  accessToken,
+  roomIdOrAlias,
+  viaServers = new Set(),
+  abortSignal,
+} = {}) {
+  const isRoomId = roomIdOrAlias.startsWith(VALID_ENTITY_DESCRIPTOR_TO_SIGIL_MAP.roomid);
+  const isRoomAlias = roomIdOrAlias.startsWith(VALID_ENTITY_DESCRIPTOR_TO_SIGIL_MAP.r);
+
+  if (isRoomId) {
+    const roomId = roomIdOrAlias;
+    return { roomId, viaServers };
+  } else if (isRoomAlias) {
+    const roomAlias = roomIdOrAlias;
+
+    const { roomId, viaServers: moreViaServers } = await resolveRoomAlias({
+      accessToken,
+      roomAlias,
+      abortSignal: abortSignal,
+    });
+    return { roomId, viaServers: new Set([...viaServers, ...moreViaServers]) };
+  }
+
+  throw new Error(
+    `resolveRoomIdOrAlias: Unknown roomIdOrAlias=${roomIdOrAlias} does not start with valid sigil (${Object.values(
+      VALID_ENTITY_DESCRIPTOR_TO_SIGIL_MAP
+    )})`
+  );
+}
+
+module.exports = resolveRoomIdOrAlias;

--- a/server/routes/room-routes.js
+++ b/server/routes/room-routes.js
@@ -18,7 +18,6 @@ const {
   fetchSuccessorInfo,
 } = require('../lib/matrix-utils/fetch-room-data');
 const fetchEventsFromTimestampBackwards = require('../lib/matrix-utils/fetch-events-from-timestamp-backwards');
-const ensureRoomJoined = require('../lib/matrix-utils/ensure-room-joined');
 const createRetryFnIfNotJoined = require('../lib/matrix-utils/create-retry-fn-if-not-joined');
 const resolveRoomIdOrAlias = require('../lib/matrix-utils/resolve-room-id-or-alias');
 const timestampToEvent = require('../lib/matrix-utils/timestamp-to-event');
@@ -181,21 +180,32 @@ router.get(
     // the time before we join and looking backwards.
     const dateBeforeJoin = Date.now();
 
-    // We have to wait for the room join to happen first before we can fetch
-    // any of the additional room info or messages.
-    const roomId = await ensureRoomJoined(matrixAccessToken, roomIdOrAlias, {
-      viaServers: parseViaServersFromUserInput(req.query.via),
+    // Resolve the room ID without joining the room (optimistically assume that we're
+    // already joined)
+    let viaServers = parseViaServersFromUserInput(req.query.via);
+    let roomId;
+    ({ roomId, viaServers } = await resolveRoomIdOrAlias({
+      accessToken: matrixAccessToken,
+      roomIdOrAlias,
+      viaServers,
+      abortSignal: req.abortSignal,
+    }));
+    // And then we can always retry after joining if we fail somewhere
+    const retryFnIfNotJoined = createRetryFnIfNotJoined(matrixAccessToken, roomIdOrAlias, {
+      viaServers,
       abortSignal: req.abortSignal,
     });
 
     // Find the closest day to the current time with messages
-    const { originServerTs } = await timestampToEvent({
-      accessToken: matrixAccessToken,
-      roomId,
-      ts: dateBeforeJoin,
-      direction: DIRECTION.backward,
-      abortSignal: req.abortSignal,
-    });
+    const { originServerTs } = await retryFnIfNotJoined(() =>
+      timestampToEvent({
+        accessToken: matrixAccessToken,
+        roomId,
+        ts: dateBeforeJoin,
+        direction: DIRECTION.backward,
+        abortSignal: req.abortSignal,
+      })
+    );
     if (!originServerTs) {
       throw new StatusError(404, 'Unable to find day with history');
     }
@@ -203,8 +213,8 @@ router.get(
     // Redirect to a day with messages
     res.redirect(
       matrixPublicArchiveURLCreator.archiveUrlForDate(roomIdOrAlias, new Date(originServerTs), {
-        // We can avoid passing along the `via` query parameter because we already
-        // joined the room above (see `ensureRoomJoined`).
+        // We can avoid passing along the `viaServers` because our server already knows
+        // about the room given that we fetched data about it already.
         //
         //viaServers: parseViaServersFromUserInput(req.query.via),
       })
@@ -253,10 +263,18 @@ router.get(
       `?timelineEndEventId must be a string or undefined but saw ${typeof timelineStartEventId}`
     );
 
-    // We have to wait for the room join to happen first before we can use the jump to
-    // date endpoint (or any other Matrix endpoint)
-    const viaServers = parseViaServersFromUserInput(req.query.via);
-    const roomId = await ensureRoomJoined(matrixAccessToken, roomIdOrAlias, {
+    // Resolve the room ID without joining the room (optimistically assume that we're
+    // already joined)
+    let viaServers = parseViaServersFromUserInput(req.query.via);
+    let roomId;
+    ({ roomId, viaServers } = await resolveRoomIdOrAlias({
+      accessToken: matrixAccessToken,
+      roomIdOrAlias,
+      viaServers,
+      abortSignal: req.abortSignal,
+    }));
+    // And then we can always retry after joining if we fail somewhere
+    const retryFnIfNotJoined = createRetryFnIfNotJoined(matrixAccessToken, roomIdOrAlias, {
       viaServers,
       abortSignal: req.abortSignal,
     });
@@ -298,28 +316,32 @@ router.get(
       // Find the closest event to the given timestamp
       [{ eventId: eventIdForClosestEvent, originServerTs: tsForClosestEvent }, roomCreateEventId] =
         await Promise.all([
-          timestampToEvent({
-            accessToken: matrixAccessToken,
-            roomId,
-            ts: ts,
-            direction: dir,
-            // Since timestamps are untrusted and can be crafted to make loops in the
-            // timeline. We use this as a signal to keep progressing from this event
-            // regardless of what timestamp shenanigans are going on. See MSC3999
-            // (https://github.com/matrix-org/matrix-spec-proposals/pull/3999)
-            //
-            // TODO: Add tests for timestamp loops once Synapse supports MSC3999. We
-            // currently just have this set in case some server has this implemented in
-            // the future but there currently is no implementation (as of 2023-04-17) and
-            // we can't have passing tests without a server implementation first.
-            //
-            // TODO: This isn't implemented yet
-            fromCausalEventId,
-            abortSignal: req.abortSignal,
-          }),
-          removeMe_fetchRoomCreateEventId(matrixAccessToken, roomId, {
-            abortSignal: req.abortSignal,
-          }),
+          retryFnIfNotJoined(() =>
+            timestampToEvent({
+              accessToken: matrixAccessToken,
+              roomId,
+              ts: ts,
+              direction: dir,
+              // Since timestamps are untrusted and can be crafted to make loops in the
+              // timeline. We use this as a signal to keep progressing from this event
+              // regardless of what timestamp shenanigans are going on. See MSC3999
+              // (https://github.com/matrix-org/matrix-spec-proposals/pull/3999)
+              //
+              // TODO: Add tests for timestamp loops once Synapse supports MSC3999. We
+              // currently just have this set in case some server has this implemented in
+              // the future but there currently is no implementation (as of 2023-04-17) and
+              // we can't have passing tests without a server implementation first.
+              //
+              // TODO: This isn't implemented yet
+              fromCausalEventId,
+              abortSignal: req.abortSignal,
+            })
+          ),
+          retryFnIfNotJoined(() =>
+            removeMe_fetchRoomCreateEventId(matrixAccessToken, roomId, {
+              abortSignal: req.abortSignal,
+            })
+          ),
         ]);
 
       // Without MSC3999, we currently only detect one kind of loop where the
@@ -444,14 +466,16 @@ router.get(
         // for the actual room display that we redirect to from this route. No need for
         // us go out 100 messages, only for us to go backwards 100 messages again in the
         // next route.
-        const messageResData = await getMessagesResponseFromEventId({
-          accessToken: matrixAccessToken,
-          roomId,
-          eventId: eventIdForClosestEvent,
-          dir: DIRECTION.forward,
-          limit: archiveMessageLimit,
-          abortSignal: req.abortSignal,
-        });
+        const messageResData = await retryFnIfNotJoined(() =>
+          getMessagesResponseFromEventId({
+            accessToken: matrixAccessToken,
+            roomId,
+            eventId: eventIdForClosestEvent,
+            dir: DIRECTION.forward,
+            limit: archiveMessageLimit,
+            abortSignal: req.abortSignal,
+          })
+        );
 
         if (!messageResData.chunk?.length) {
           throw new StatusError(
@@ -584,9 +608,11 @@ router.get(
             predecessorRoomId,
             predecessorLastKnownEventId,
             predecessorViaServers,
-          } = await fetchPredecessorInfo(matrixAccessToken, roomId, {
-            abortSignal: req.abortSignal,
-          });
+          } = await retryFnIfNotJoined(() =>
+            fetchPredecessorInfo(matrixAccessToken, roomId, {
+              abortSignal: req.abortSignal,
+            })
+          );
 
           if (!predecessorRoomId) {
             throw new StatusError(
@@ -595,18 +621,24 @@ router.get(
             );
           }
 
-          // We have to join the predecessor room before we can fetch the successor info
-          // (this could be our first time seeing the room)
-          await ensureRoomJoined(matrixAccessToken, predecessorRoomId, {
-            viaServers,
-            abortSignal: req.abortSignal,
-          });
+          // We can always retry after joining if we fail somewhere
+          const retryFnIfNotJoinedToPredecessorRoom = createRetryFnIfNotJoined(
+            matrixAccessToken,
+            predecessorRoomId,
+            {
+              viaServers,
+              abortSignal: req.abortSignal,
+            }
+          );
+
           const {
             successorRoomId: successorRoomIdForPredecessor,
             successorSetTs: successorSetTsForPredecessor,
-          } = await fetchSuccessorInfo(matrixAccessToken, predecessorRoomId, {
-            abortSignal: req.abortSignal,
-          });
+          } = await retryFnIfNotJoinedToPredecessorRoom(() =>
+            fetchSuccessorInfo(matrixAccessToken, predecessorRoomId, {
+              abortSignal: req.abortSignal,
+            })
+          );
 
           let tombstoneEventId;
           if (!predecessorLastKnownEventId) {
@@ -617,13 +649,15 @@ router.get(
             //
             // We just assume this is the tombstone event ID but in any case it gets us to
             // an event that happened at the same time.
-            ({ eventId: tombstoneEventId } = await timestampToEvent({
-              accessToken: matrixAccessToken,
-              roomId: predecessorRoomId,
-              ts: successorSetTsForPredecessor,
-              direction: DIRECTION.backward,
-              abortSignal: req.abortSignal,
-            }));
+            ({ eventId: tombstoneEventId } = await retryFnIfNotJoinedToPredecessorRoom(() =>
+              timestampToEvent({
+                accessToken: matrixAccessToken,
+                roomId: predecessorRoomId,
+                ts: successorSetTsForPredecessor,
+                direction: DIRECTION.backward,
+                abortSignal: req.abortSignal,
+              })
+            ));
           }
 
           // Try to continue from the tombstone event in the predecessor room because
@@ -685,9 +719,11 @@ router.get(
           );
           return;
         } else if (dir === DIRECTION.forward) {
-          const { successorRoomId } = await fetchSuccessorInfo(matrixAccessToken, roomId, {
-            abortSignal: req.abortSignal,
-          });
+          const { successorRoomId } = await retryFnIfNotJoined(() =>
+            fetchSuccessorInfo(matrixAccessToken, roomId, {
+              abortSignal: req.abortSignal,
+            })
+          );
           if (successorRoomId) {
             // Jump to the successor room and continue at the first event of the room
             res.redirect(
@@ -800,7 +836,7 @@ router.get(
       viaServers,
       abortSignal: req.abortSignal,
     }));
-
+    // And then we can always retry after joining if we fail somewhere
     const retryFnIfNotJoined = createRetryFnIfNotJoined(matrixAccessToken, roomIdOrAlias, {
       viaServers,
       abortSignal: req.abortSignal,
@@ -932,8 +968,8 @@ router.get(
           // We purposely omit `scrollStartEventId` here because the canonical location
           // for any given event ID is the page it resides on.
           //
-          // We can avoid passing along the `viaServers` because we already joined the
-          // room above (see `ensureRoomJoined`).
+          // We can avoid passing along the `viaServers` because our server already knows about
+          // the room given that we fetched data about it already.
         }
       ),
       shouldIndex,


### PR DESCRIPTION
Previously, we would try to join the room no matter what. Now with this PR, we assume that we are already joined to the room or can peek in the `world_readable` case and only if we get a `403 Forbidden`, do we go back and try to join the room.

This has the effect of Matrix Public Archive being able to serve content from `world_readable` rooms without joining. And in the case of a `world_readable` room not being public, will still work (see case mentioned in https://github.com/matrix-org/matrix-public-archive/issues/271)

We also show `world_readable` rooms in the room directory instead of filtering them out.

Fix https://github.com/matrix-org/matrix-public-archive/issues/271

