### PR TITLE
Fix eslint trying to look at `node_modules/`

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/matrix-org/matrix-public-archive"
   },
   "scripts": {
-    "lint": "eslint **/*.js",
+    "lint": "eslint \"**/*.js\"",
     "build": "node ./build-scripts/do-client-build.js",
     "start": "node server/server.js",
     "start-dev": "node server/start-dev.js",


### PR DESCRIPTION
Fix eslint trying to look at `node_modules/`. I'm not sure what exactly is causing the behavior change now besides that I am running on Linux.

The quote fix around the path is from https://stackoverflow.com/questions/51021751/express-js-lint-gives-mistake

`node_modules/` is already part of our `.eslintignore`

https://github.com/matrix-org/matrix-public-archive/blob/1d3e930fbd57788ed60494a64835127ff97dbd53/.eslintignore#L1

Previously:

```sh
$ npm run lint

> matrix-public-archive@0.1.0 lint
> eslint **/*.js

Oops! Something went wrong! :(

ESLint: 8.37.0

You are linting "node_modules/ipaddr.js", but all of the files matching the glob pattern "node_modules/ipaddr.js" are ignored.

If you don't want to lint these files, remove the pattern "node_modules/ipaddr.js" from the list of arguments passed to ESLint.

If you do want to lint these files, try the following solutions:

* Check your .eslintignore file, or the eslintIgnore property in package.json, to ensure that the files are not configured to be ignored.
* Explicitly list the files from this glob that you'd like to lint on the command-line, rather than providing a glob as an argument.
```