### PR TITLE
Try and make the seamless pagination test more robust (wait for Synapse to settle)

### DIFF
--- a/test/e2e-tests.js
+++ b/test/e2e-tests.js
@@ -2735,10 +2735,13 @@ describe('matrix-viewer', () => {
         // doing them serially and the room directory doesn't return the rooms in any
         // particular order so it doesn't make the test any more clear doing them
         // serially anyway.
+        let lastCreatedRoomId;
         const createdRoomsIds = await Promise.all(
-          roomsConfigurationsToCreate.map((roomCreateOptions) =>
-            createTestRoom(client, roomCreateOptions)
-          )
+          roomsConfigurationsToCreate.map(async (roomCreateOptions) => {
+            const roomId = await createTestRoom(client, roomCreateOptions);
+            lastCreatedRoomId = roomId;
+            return roomId;
+          })
         );
 
         function roomIdToRoomName(expectedRoomId) {
@@ -2821,6 +2824,11 @@ describe('matrix-viewer', () => {
         await waitForResultsInHomeserverRoomDirectory({
           client,
           searchTerm: visibleRoomConfigurations[visibleRoomConfigurations.length - 1].name,
+        });
+        // Also check for the room that we last saw created as an extra measure
+        await waitForResultsInHomeserverRoomDirectory({
+          client,
+          searchTerm: roomIdToRoomName(lastCreatedRoomId),
         });
 
         // Visit a sequence of pages using the pagination links: 1 -> 2 -> 3 -> 2 -> 1


### PR DESCRIPTION
Try and make the seamless pagination test more robust (wait for Synapse to settle)

Previously was seeing some failures like this locally
```
  1 failing

  1) matrix-viewer
       Matrix Viewer
         Room directory
           pagination is seamless:

      AssertionError [ERR_ASSERTION]: Make sure we saw all visible rooms paginating through the directory
      + expected - actual

         "planet-1689366398300-room-29"
         "planet-1689366398300-room-31"
         "planet-1689366398300-room-32"
         "planet-1689366398300-room-34"
      -  "planet-1689366398300-room-34"
         "planet-1689366398300-room-35"
         "planet-1689366398300-room-37"
         "planet-1689366398300-room-38"
         "planet-1689366398300-room-4"

      at Context.<anonymous> (test/e2e-tests.js:2835:16)
      at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
```